### PR TITLE
Match editor: fix mislogged matches with stable match IDs and an audit trail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,10 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-          cache-dependency-path: backend/requirements.txt
-      - run: pip install -r requirements.txt
+          cache-dependency-path: backend/requirements-dev.txt
+      - run: pip install -r requirements-dev.txt
       - run: python -m py_compile app.py
+      - run: python -m pytest tests/ -q
       # Import-time smoke test: app must construct with a clean data dir
       - run: DATA_DIR=/tmp/ssbu-ci python -c "import app; print(len(list(app.app.url_map.iter_rules())), 'routes registered')"
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ flowchart LR
 
 - **Match logging**: character search with win rates, sticky stage selection,
   winner + stocks remaining, and a 10-second undo window after each log
+- **Match editor**: fix mislogged matches (characters, winner, stage, stocks) or
+  delete bogus rows from Recent Matches or any session's match list; every
+  edit is recorded in an audit log (`edit_log.csv`)
 - **Session tracking**: games auto-group into sessions (a 4+ hour gap starts a
   new one)
 - **Statistics dashboard**: win rates, streaks, monthly activity, top matchups,

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,11 +1,13 @@
 # app.py
 from flask import Flask, Response, request, jsonify, send_from_directory
 from datetime import datetime
+import csv
 import hmac
 import pandas as pd
 import os
 import logging
 import threading
+import uuid
 from typing import Dict, Any, Optional
 import json
 import pytz
@@ -42,6 +44,7 @@ class GameDataManager:
             "stage",
             "timestamp",  # Unix timestamp for easier time-based operations
             "session_id",  # Session identifier
+            "match_id",  # Stable per-match identifier (uuid4 hex prefix)
         ]
         self.session_gap_hours = 4  # Hours of inactivity before starting new session
         # Serializes CSV read-modify-write cycles; pandas to_csv is not atomic
@@ -49,6 +52,7 @@ class GameDataManager:
         self._ensure_csv_exists()
         self._ensure_characters_file_exists()
         self._create_session_backup()
+        self._backfill_match_ids_and_timestamps()
 
     def _ensure_csv_exists(self) -> None:
         """Create CSV file with headers if it doesn't exist."""
@@ -670,6 +674,7 @@ class GameDataManager:
                 "stage": stage_value,
                 "timestamp": timestamp,
                 "session_id": session_id,
+                "match_id": uuid.uuid4().hex[:12],
             }
 
             # Log the processed game data
@@ -719,6 +724,130 @@ class GameDataManager:
             else:
                 removed[str(key)] = value
         return removed
+
+    @staticmethod
+    def _row_to_dict(row: pd.Series) -> Dict[str, Any]:
+        """Convert a DataFrame row to a plain JSON-serializable dict."""
+        out: Dict[str, Any] = {}
+        for key, value in row.items():
+            if pd.isna(value):
+                out[str(key)] = None
+            elif hasattr(value, "item"):
+                out[str(key)] = value.item()
+            else:
+                out[str(key)] = value
+        return out
+
+    def _backfill_match_ids_and_timestamps(self) -> None:
+        """Idempotent startup repair pass (mirrors the lazy session-id backfill):
+        derive missing unix timestamps from datetime strings, and assign a
+        match_id to every row that lacks one. Reads the raw CSV so no rows are
+        silently dropped by _load_data's cleaning."""
+        try:
+            with self._write_lock:
+                df = pd.read_csv(self.csv_path)
+                if len(df) == 0:
+                    return
+                changed = False
+                if "match_id" not in df.columns:
+                    df["match_id"] = pd.NA
+                    changed = True
+
+                df["timestamp"] = pd.to_numeric(df["timestamp"], errors="coerce")
+                eastern = pytz.timezone("US/Eastern")
+                missing_ts = df["timestamp"].isna() & df["datetime"].notna()
+                for idx in df.index[missing_ts]:
+                    try:
+                        dt = datetime.strptime(
+                            str(df.at[idx, "datetime"]), "%Y-%m-%d %H:%M:%S"
+                        )
+                        df.at[idx, "timestamp"] = eastern.localize(dt).timestamp()
+                        changed = True
+                    except ValueError:
+                        logger.warning(f"Backfill: unparseable datetime at row {idx}")
+
+                ids = df["match_id"].astype("string")
+                missing_id = ids.isna() | (ids.str.strip() == "")
+                n_missing_ids = int(missing_id.sum())
+                if n_missing_ids:
+                    df.loc[missing_id, "match_id"] = [
+                        uuid.uuid4().hex[:12] for _ in range(n_missing_ids)
+                    ]
+                    changed = True
+
+                if changed:
+                    columns_to_save = [c for c in self.columns if c in df.columns]
+                    df[columns_to_save].to_csv(self.csv_path, index=False)
+                    logger.info(
+                        f"Backfill: filled {int(missing_ts.sum())} timestamps, "
+                        f"{n_missing_ids} match_ids"
+                    )
+        except Exception as e:
+            # Never block startup on the repair pass
+            logger.error(f"Error during match-id/timestamp backfill: {str(e)}")
+
+    @staticmethod
+    def _find_row_index(df: pd.DataFrame, match_id: str) -> Optional[Any]:
+        """Locate the DataFrame index of a match by its match_id."""
+        if "match_id" not in df.columns:
+            return None
+        hits = df.index[df["match_id"].astype(str) == str(match_id)]
+        return hits[0] if len(hits) else None
+
+    def get_matches(
+        self,
+        session_id: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Dict[str, Any]:
+        """Paginated match list, newest first, optionally scoped to a session."""
+        df = self._load_data()
+        df["timestamp"] = pd.to_numeric(df["timestamp"], errors="coerce")
+        if session_id:
+            df = df[df["session_id"] == session_id]
+        df = df.sort_values("timestamp", ascending=False)
+        total = len(df)
+        page = df.iloc[offset : offset + limit].fillna("")
+        return {"matches": page.to_dict("records"), "total": total}
+
+    def update_match(
+        self, match_id: str, updates: Dict[str, Any]
+    ) -> Optional[Dict[str, Dict[str, Any]]]:
+        """Apply pre-validated column updates to one match.
+
+        Returns {"before": ..., "after": ...} or None if the id is unknown.
+        Reads the raw CSV so unrelated malformed rows are never dropped.
+        """
+        with self._write_lock:
+            df = pd.read_csv(self.csv_path)
+            idx = self._find_row_index(df, match_id)
+            if idx is None:
+                return None
+            before = self._row_to_dict(df.loc[idx])
+            for col, value in updates.items():
+                df.at[idx, col] = value
+            columns_to_save = [c for c in self.columns if c in df.columns]
+            df[columns_to_save].to_csv(self.csv_path, index=False)
+            after = self._row_to_dict(df.loc[idx])
+        return {"before": before, "after": after}
+
+    def delete_match(self, match_id: str) -> Optional[Dict[str, Any]]:
+        """Remove one match by id. Returns the removed row or None if unknown."""
+        with self._write_lock:
+            df = pd.read_csv(self.csv_path)
+            idx = self._find_row_index(df, match_id)
+            if idx is None:
+                return None
+            removed = self._row_to_dict(df.loc[idx])
+            df = df.drop(index=idx)
+            columns_to_save = [c for c in self.columns if c in df.columns]
+            df[columns_to_save].to_csv(self.csv_path, index=False)
+        return removed
+
+    def get_character_roster(self) -> list:
+        """The raw character list used for validation and pickers."""
+        with open(self.characters_path) as f:
+            return json.load(f)
 
     def get_recent_games(self, n: int = 5) -> pd.DataFrame:
         """Get the n most recent games."""
@@ -1175,6 +1304,150 @@ def undo_last_game() -> Any:
         return jsonify({"success": True, "removed": removed})
     except Exception as e:
         logger.error(f"Error in undo_last_game endpoint: {str(e)}")
+        return jsonify({"success": False, "message": str(e)}), 500
+
+
+# All stages that can appear on a match: the 8 currently-selectable stages,
+# Yoshi's Story (historical matches), and the no-stage placeholder.
+VALID_STAGES = {
+    "Battlefield",
+    "Small Battlefield",
+    "Final Destination",
+    "Pokemon Stadium 2",
+    "Smashville",
+    "Town & City",
+    "Kalos Pokemon League",
+    "Yoshi's Story",
+    "Hollow Bastion",
+    "No Stage",
+}
+
+# Request-body field -> CSV column for match edits
+MATCH_EDIT_FIELDS = {
+    "shayneCharacter": "shayne_character",
+    "mattCharacter": "matt_character",
+    "winner": "winner",
+    "stage": "stage",
+    "stocksRemaining": "stocks_remaining",
+}
+
+
+def _validate_match_updates(
+    data: Dict[str, Any],
+) -> tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Validate an edit payload. Returns (column_updates, None) or (None, error)."""
+    if not data:
+        return None, "No fields provided"
+    unknown = [k for k in data if k not in MATCH_EDIT_FIELDS]
+    if unknown:
+        return None, f"Unknown fields: {', '.join(unknown)}"
+    roster = set(data_manager.get_character_roster())
+    updates: Dict[str, Any] = {}
+    for key, value in data.items():
+        if key in ("shayneCharacter", "mattCharacter"):
+            if value not in roster:
+                return None, f"Unknown character: {value}"
+        elif key == "winner":
+            if value not in ("Shayne", "Matt"):
+                return None, "winner must be 'Shayne' or 'Matt'"
+        elif key == "stage":
+            # Canonicalize the editor's empty-string "no stage" to the CSV convention
+            value = value or "No Stage"
+            if value not in VALID_STAGES:
+                return None, f"Unknown stage: {value}"
+        elif key == "stocksRemaining":
+            if value is not None and (
+                not isinstance(value, int)
+                or isinstance(value, bool)
+                or not 1 <= value <= 3
+            ):
+                return None, "stocksRemaining must be 1-3 or null"
+        updates[MATCH_EDIT_FIELDS[key]] = value
+    return updates, None
+
+
+def _append_edit_log(
+    action: str,
+    match_id: str,
+    before: Optional[Dict[str, Any]],
+    after: Optional[Dict[str, Any]],
+) -> None:
+    """Audit trail for match edits/deletes: one CSV row per action.
+
+    Editor is the Basic-auth username (empty in dev). Failures are logged,
+    never raised — the edit itself has already succeeded.
+    """
+    try:
+        auth = request.authorization
+        editor = auth.username if auth and auth.username else ""
+        log_path = os.path.join(DATA_DIR, "edit_log.csv")
+        new_file = not os.path.exists(log_path)
+        with open(log_path, "a", newline="") as f:
+            writer = csv.writer(f)
+            if new_file:
+                writer.writerow(
+                    ["edited_at", "editor", "action", "match_id", "before", "after"]
+                )
+            writer.writerow(
+                [
+                    datetime.now(pytz.timezone("US/Eastern")).strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    ),
+                    editor,
+                    action,
+                    match_id,
+                    json.dumps(before),
+                    json.dumps(after),
+                ]
+            )
+    except Exception as e:
+        logger.error(f"Error writing edit log: {str(e)}")
+
+
+@app.route("/api/matches", methods=["GET"])
+def api_list_matches() -> Any:
+    """Paginated match list, newest first; filterable by session_id."""
+    try:
+        session_id = request.args.get("session_id")
+        limit = min(int(request.args.get("limit", 50)), 200)
+        offset = max(int(request.args.get("offset", 0)), 0)
+        result = data_manager.get_matches(
+            session_id=session_id, limit=limit, offset=offset
+        )
+        return jsonify({"success": True, **result})
+    except Exception as e:
+        logger.error(f"Error listing matches: {str(e)}")
+        return jsonify({"success": False, "message": str(e)}), 500
+
+
+@app.route("/api/matches/<match_id>", methods=["PUT"])
+def api_update_match(match_id: str) -> Any:
+    """Edit a match's characters, winner, stage, or stocks."""
+    try:
+        updates, err = _validate_match_updates(request.json or {})
+        if err:
+            return jsonify({"success": False, "message": err}), 400
+        result = data_manager.update_match(match_id, updates or {})
+        if result is None:
+            return jsonify({"success": False, "message": "Match not found"}), 404
+        _append_edit_log("update", match_id, result["before"], result["after"])
+        return jsonify({"success": True, "match": result["after"]})
+    except Exception as e:
+        logger.error(f"Error updating match {match_id}: {str(e)}")
+        return jsonify({"success": False, "message": str(e)}), 500
+
+
+@app.route("/api/matches/<match_id>", methods=["DELETE"])
+def api_delete_match(match_id: str) -> Any:
+    """Delete a mislogged match entirely (recorded in the edit log)."""
+    try:
+        removed = data_manager.delete_match(match_id)
+        if removed is None:
+            return jsonify({"success": False, "message": "Match not found"}), 404
+        _append_edit_log("delete", match_id, removed, None)
+        return jsonify({"success": True, "removed": removed})
+    except Exception as e:
+        logger.error(f"Error deleting match {match_id}: {str(e)}")
         return jsonify({"success": False, "message": str(e)}), 500
 
 

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==8.3.4

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,79 @@
+"""Fixtures for backend API tests.
+
+The app module holds a module-level GameDataManager bound to DATA_DIR at
+import time, so DATA_DIR is pointed at a temp dir and the CSV seeded BEFORE
+the one-and-only `import app`. Each test rewrites the seed and re-runs the
+idempotent backfill for isolation.
+"""
+
+import importlib
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict, List
+
+import pandas as pd
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND_DIR))
+
+SEED_ROWS: List[Dict[str, Any]] = [
+    {
+        # Modern row: complete
+        "datetime": "2025-12-11 21:05:18",
+        "shayne_character": "Fox",
+        "matt_character": "Falco",
+        "winner": "Matt",
+        "stocks_remaining": 2,
+        "stage": "Battlefield",
+        "timestamp": 1765505118.0,
+        "session_id": "2025-12-11-21",
+        "match_id": "seedmatch0001",
+    },
+    {
+        # Legacy row: missing timestamp and match_id (the 218-row historical case)
+        "datetime": "2025-10-25 18:54:03",
+        "shayne_character": "Donkey Kong",
+        "matt_character": "Kirby",
+        "winner": "Shayne",
+        "stocks_remaining": 1,
+        "stage": "Smashville",
+        "timestamp": None,
+        "session_id": "2025-10-25-18",
+        "match_id": None,
+    },
+]
+
+
+def _write_seed(csv_path: Path) -> None:
+    pd.DataFrame(SEED_ROWS).to_csv(csv_path, index=False)
+
+
+@pytest.fixture(scope="session")
+def appmod(tmp_path_factory: pytest.TempPathFactory) -> ModuleType:
+    data_dir = tmp_path_factory.mktemp("ssbu-data")
+    os.environ["DATA_DIR"] = str(data_dir)
+    os.environ.pop("SITE_PASSWORD", None)
+    # characters.json is resolved relative to cwd
+    os.chdir(BACKEND_DIR)
+    _write_seed(data_dir / "game_results.csv")
+    module = importlib.import_module("app")
+    return module
+
+
+@pytest.fixture()
+def client(appmod: ModuleType):
+    """Fresh seed + backfill + test client per test."""
+    _write_seed(Path(appmod.DATA_DIR) / "game_results.csv")
+    edit_log = Path(appmod.DATA_DIR) / "edit_log.csv"
+    if edit_log.exists():
+        edit_log.unlink()
+    appmod.data_manager._backfill_match_ids_and_timestamps()
+    return appmod.app.test_client()
+
+
+@pytest.fixture()
+def data_dir(appmod: ModuleType) -> Path:
+    return Path(appmod.DATA_DIR)

--- a/backend/tests/test_match_editor.py
+++ b/backend/tests/test_match_editor.py
@@ -1,0 +1,121 @@
+"""Tests for match identity backfill and the match-editor API."""
+
+from pathlib import Path
+
+import pandas as pd
+
+
+def _read_csv(data_dir: Path) -> pd.DataFrame:
+    return pd.read_csv(data_dir / "game_results.csv")
+
+
+class TestBackfill:
+    def test_assigns_match_ids_and_timestamps(self, client, data_dir: Path) -> None:
+        df = _read_csv(data_dir)
+        assert df["match_id"].notna().all()
+        assert df["match_id"].nunique() == len(df)
+        assert df["timestamp"].notna().all()
+        # Existing ids are preserved
+        assert "seedmatch0001" in set(df["match_id"])
+
+    def test_idempotent(self, client, appmod, data_dir: Path) -> None:
+        before = _read_csv(data_dir)
+        appmod.data_manager._backfill_match_ids_and_timestamps()
+        after = _read_csv(data_dir)
+        assert list(before["match_id"]) == list(after["match_id"])
+        assert list(before["timestamp"]) == list(after["timestamp"])
+
+
+class TestListMatches:
+    def test_lists_newest_first_with_ids(self, client) -> None:
+        res = client.get("/api/matches")
+        body = res.get_json()
+        assert res.status_code == 200 and body["success"]
+        assert body["total"] == 2
+        assert body["matches"][0]["match_id"] == "seedmatch0001"
+        assert all(m["match_id"] for m in body["matches"])
+
+    def test_session_filter(self, client) -> None:
+        body = client.get("/api/matches?session_id=2025-10-25-18").get_json()
+        assert body["total"] == 1
+        assert body["matches"][0]["shayne_character"] == "Donkey Kong"
+
+
+class TestUpdateMatch:
+    def test_updates_fields(self, client, data_dir: Path) -> None:
+        res = client.put(
+            "/api/matches/seedmatch0001",
+            json={"winner": "Shayne", "stocksRemaining": 3, "stage": "Yoshi's Story"},
+        )
+        body = res.get_json()
+        assert res.status_code == 200 and body["success"]
+        assert body["match"]["winner"] == "Shayne"
+        row = _read_csv(data_dir).set_index("match_id").loc["seedmatch0001"]
+        assert row["winner"] == "Shayne"
+        assert int(row["stocks_remaining"]) == 3
+        assert row["stage"] == "Yoshi's Story"
+
+    def test_writes_edit_log(self, client, data_dir: Path) -> None:
+        client.put("/api/matches/seedmatch0001", json={"winner": "Shayne"})
+        log = pd.read_csv(data_dir / "edit_log.csv")
+        assert len(log) == 1
+        assert log.iloc[0]["action"] == "update"
+        assert log.iloc[0]["match_id"] == "seedmatch0001"
+
+    def test_validation_errors(self, client) -> None:
+        cases = [
+            {"shayneCharacter": "NotACharacter"},
+            {"winner": "Jaspreet"},
+            {"stage": "Fountain of Dreams"},
+            {"stocksRemaining": 5},
+            {"bogusField": 1},
+            {},
+        ]
+        for payload in cases:
+            res = client.put("/api/matches/seedmatch0001", json=payload)
+            assert res.status_code == 400, payload
+            assert res.get_json()["success"] is False
+
+    def test_empty_stage_canonicalizes_to_no_stage(self, client, data_dir: Path) -> None:
+        res = client.put("/api/matches/seedmatch0001", json={"stage": ""})
+        assert res.status_code == 200
+        row = _read_csv(data_dir).set_index("match_id").loc["seedmatch0001"]
+        assert row["stage"] == "No Stage"
+
+    def test_unknown_id_404(self, client) -> None:
+        res = client.put("/api/matches/doesnotexist", json={"winner": "Matt"})
+        assert res.status_code == 404
+
+
+class TestDeleteMatch:
+    def test_deletes_and_logs(self, client, data_dir: Path) -> None:
+        res = client.delete("/api/matches/seedmatch0001")
+        assert res.status_code == 200 and res.get_json()["success"]
+        df = _read_csv(data_dir)
+        assert len(df) == 1
+        assert "seedmatch0001" not in set(df["match_id"])
+        log = pd.read_csv(data_dir / "edit_log.csv")
+        assert log.iloc[0]["action"] == "delete"
+
+    def test_double_delete_404(self, client) -> None:
+        assert client.delete("/api/matches/seedmatch0001").status_code == 200
+        assert client.delete("/api/matches/seedmatch0001").status_code == 404
+
+
+class TestLogGame:
+    def test_new_games_get_match_ids(self, client, data_dir: Path) -> None:
+        res = client.post(
+            "/api/log_game",
+            json={
+                "shayneCharacter": "Fox",
+                "mattCharacter": "Marth",
+                "stage": "Battlefield",
+                "winner": "Matt",
+                "stocksRemaining": 1,
+            },
+        )
+        assert res.status_code == 200
+        df = _read_csv(data_dir)
+        assert len(df) == 3
+        newest = df.loc[pd.to_numeric(df["timestamp"]).idxmax()]
+        assert isinstance(newest["match_id"], str) and len(newest["match_id"]) == 12

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -78,6 +78,14 @@ It never deploys — deploys stay manual, same as nesty.
 | Shell into machine | `fly ssh console` |
 | Pull data down | `fly ssh sftp get /data/game_results.csv` |
 
+## One-time CSV rewrite on upgrade (match-editor release)
+
+The first boot after deploying the match-editor release runs an idempotent
+repair pass: it adds a `match_id` column and derives missing unix timestamps
+from `datetime` strings (218 legacy rows). The whole CSV is rewritten once,
+under the write lock, with the boot backup taken beforehand. Subsequent boots
+are no-ops. Match edits/deletes are audited in `/data/edit_log.csv`.
+
 ## Backups
 
 1. **Fly volume snapshots** — automatic, block-level, `snapshot_retention = 14` days (configured in fly.toml).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,6 +39,13 @@ zero tests, two-player assumption baked into the CSV schema itself
 - 404 route; dead plotly stub, stray root `package.json`, and empty backend
   scaffold dirs removed; `frontend/package-lock.json` now committed (CI/Docker
   need it).
+- **Match editor** (2026-07-14): every match has a stable `match_id`
+  (idempotent startup backfill, which also repaired 218 legacy rows missing
+  timestamps); `GET /api/matches`, `PUT/DELETE /api/matches/<id>` with
+  validation + `edit_log.csv` audit trail; edit modal reachable from Recent
+  Matches and session detail. First backend pytest suite landed with it
+  (seed of the P2 characterization harness). `match_id` becomes the primary
+  key in the P2 SQLite migration.
 
 **Known debt** (ranked, from the survey):
 

--- a/frontend/src/RecentMatches.tsx
+++ b/frontend/src/RecentMatches.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useState, forwardRef, useImperativeHandle } from 'react';
 import CharacterDisplay from './components/CharacterDisplay';
+import MatchEditorModal from './components/MatchEditorModal';
 
 interface Game {
+  match_id: string;
   datetime: string;
   shayne_character: string;
   matt_character: string;
   winner: string;
   stage: string;
   stocks_remaining: number;
+  session_id?: string;
 }
 
 export interface RecentMatchesRef {
@@ -18,6 +21,7 @@ const RecentMatches = forwardRef<RecentMatchesRef>((_props, ref) => {
   const [matches, setMatches] = useState<Game[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [editingMatch, setEditingMatch] = useState<Game | null>(null);
 
   const fetchMatches = async () => {
     setLoading(true);
@@ -68,8 +72,8 @@ const RecentMatches = forwardRef<RecentMatchesRef>((_props, ref) => {
         {!loading && !error && matches.map((game, idx) => {
           const isShayneWin = game.winner === 'Shayne';
           return (
-            <div 
-              key={idx}
+            <div
+              key={game.match_id || idx}
               style={{
                 background: '#3c3836',
                 borderRadius: '8px',
@@ -125,20 +129,50 @@ const RecentMatches = forwardRef<RecentMatchesRef>((_props, ref) => {
                     gap: '0.2rem'
                   }}>
                     {[...Array(game.stocks_remaining)].map((_, i) => (
-                      <div key={i} style={{ 
-                        width: '6px', 
-                        height: '6px', 
-                        borderRadius: '50%', 
-                        background: isShayneWin ? '#fe8019' : '#b8bb26' 
+                      <div key={i} style={{
+                        width: '6px',
+                        height: '6px',
+                        borderRadius: '50%',
+                        background: isShayneWin ? '#fe8019' : '#b8bb26'
                       }} />
                     ))}
                   </div>
                 </div>
+                <button
+                  type="button"
+                  aria-label="Edit match"
+                  title="Edit match"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setEditingMatch(game);
+                  }}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    color: '#a89984',
+                    fontSize: '0.85rem',
+                    cursor: 'pointer',
+                    padding: '0 0 0 0.4rem',
+                    lineHeight: 1,
+                    alignSelf: 'flex-start'
+                  }}
+                  onMouseEnter={(e) => { e.currentTarget.style.color = '#fbf1c7'; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.color = '#a89984'; }}
+                >
+                  ✎
+                </button>
               </div>
             </div>
           );
         })}
       </div>
+      {editingMatch && (
+        <MatchEditorModal
+          match={editingMatch}
+          onClose={() => setEditingMatch(null)}
+          onSaved={fetchMatches}
+        />
+      )}
     </div>
   );
 });

--- a/frontend/src/SessionDetail.tsx
+++ b/frontend/src/SessionDetail.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import * as echarts from 'echarts';
 import CharacterDisplay from './components/CharacterDisplay';
+import MatchEditorModal, { type EditableMatch } from './components/MatchEditorModal';
 import { LoadingState, ErrorState } from './components/Feedback';
 import { stageImages } from './lib/stages';
 
@@ -25,16 +26,28 @@ interface SessionStats {
   }>;
 }
 
+interface SessionMatchesResponse {
+  success: boolean;
+  matches: EditableMatch[];
+  total: number;
+  message?: string;
+}
+
 function SessionDetail() {
   const { session_id } = useParams<{ session_id: string }>();
   const [stats, setStats] = useState<SessionStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [matches, setMatches] = useState<EditableMatch[]>([]);
+  const [matchesLoading, setMatchesLoading] = useState(true);
+  const [matchesError, setMatchesError] = useState<string | null>(null);
+  const [editingMatch, setEditingMatch] = useState<EditableMatch | null>(null);
   const chartRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (session_id) {
       fetchSessionStats();
+      fetchMatches();
     }
   }, [session_id]);
 
@@ -44,17 +57,42 @@ function SessionDetail() {
     try {
       const res = await fetch(`/api/sessions/${session_id}`);
       const data = await res.json();
-      
+
       if (!data.success) {
         throw new Error(data.message || 'Failed to load session stats');
       }
-      
+
       setStats(data);
     } catch (err: any) {
       setError(err.message);
     } finally {
       setLoading(false);
     }
+  };
+
+  const fetchMatches = async () => {
+    if (!session_id) return;
+    setMatchesLoading(true);
+    setMatchesError(null);
+    try {
+      const res = await fetch(`/api/matches?session_id=${encodeURIComponent(session_id)}&limit=200`);
+      const data: SessionMatchesResponse = await res.json();
+
+      if (!data.success) {
+        throw new Error(data.message || 'Failed to load session matches');
+      }
+
+      setMatches(data.matches);
+    } catch (err: unknown) {
+      setMatchesError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setMatchesLoading(false);
+    }
+  };
+
+  const handleMatchSaved = () => {
+    fetchMatches();
+    fetchSessionStats();
   };
 
   // Mini donut chart
@@ -107,6 +145,16 @@ function SessionDetail() {
       hour: 'numeric',
       minute: '2-digit'
     });
+  };
+
+  const formatMatchTime = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
+  };
+
+  const formatStocks = (value: EditableMatch['stocks_remaining']): string => {
+    if (value === null || value === undefined || value === '') return '—';
+    return `${value} stk`;
   };
 
   const calculateDuration = () => {
@@ -458,6 +506,107 @@ function SessionDetail() {
             ))}
           </div>
         </div>
+      )}
+
+      {/* Matches */}
+      <div style={{ marginTop: '2rem' }}>
+        <h3 style={{ fontSize: '1.3rem', marginBottom: '1rem', color: '#fbf1c7', fontWeight: 'bold' }}>
+          Matches
+        </h3>
+        <div style={{
+          background: '#3c3836',
+          borderRadius: '12px',
+          border: '1px solid #504945',
+          padding: '0.75rem'
+        }}>
+          {matchesLoading && (
+            <div style={{ fontSize: '0.85rem', color: '#a89984', padding: '0.5rem' }}>Loading matches...</div>
+          )}
+          {matchesError && (
+            <div className="error" style={{ fontSize: '0.85rem', padding: '0.5rem' }}>{matchesError}</div>
+          )}
+          {!matchesLoading && !matchesError && matches.length === 0 && (
+            <div style={{ fontSize: '0.85rem', color: '#a89984', padding: '0.5rem' }}>No matches found for this session.</div>
+          )}
+          {!matchesLoading && !matchesError && matches.map((match) => {
+            const isShayneWin = match.winner === 'Shayne';
+            return (
+              <div
+                key={match.match_id}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.75rem',
+                  flexWrap: 'wrap',
+                  padding: '0.6rem 0.5rem',
+                  borderBottom: '1px solid #504945',
+                  borderLeft: `3px solid ${isShayneWin ? '#fe8019' : '#b8bb26'}`,
+                  borderRadius: '4px',
+                  marginBottom: '0.25rem',
+                  background: '#32302f'
+                }}
+              >
+                <span style={{ fontSize: '0.75rem', color: '#a89984', fontVariantNumeric: 'tabular-nums', minWidth: '40px' }}>
+                  {formatMatchTime(match.datetime)}
+                </span>
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.4rem', flex: 1, minWidth: '160px', fontSize: '0.85rem' }}>
+                  <span style={{ color: '#fe8019' }}>
+                    <CharacterDisplay character={match.shayne_character} />
+                  </span>
+                  <span style={{ color: '#a89984', fontSize: '0.75rem' }}>vs</span>
+                  <span style={{ color: '#b8bb26' }}>
+                    <CharacterDisplay character={match.matt_character} />
+                  </span>
+                </span>
+                <span style={{
+                  fontSize: '0.7rem',
+                  fontWeight: 'bold',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.5px',
+                  color: '#282828',
+                  background: isShayneWin ? '#fe8019' : '#b8bb26',
+                  borderRadius: '4px',
+                  padding: '0.15rem 0.5rem'
+                }}>
+                  {match.winner}
+                </span>
+                <span style={{ fontSize: '0.75rem', color: '#a89984', minWidth: '90px' }}>
+                  {match.stage || 'No stage'}
+                </span>
+                <span style={{ fontSize: '0.75rem', color: '#a89984', minWidth: '38px', textAlign: 'right' }}>
+                  {formatStocks(match.stocks_remaining)}
+                </span>
+                <button
+                  type="button"
+                  aria-label="Edit match"
+                  title="Edit match"
+                  onClick={() => setEditingMatch(match)}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    color: '#a89984',
+                    fontSize: '0.9rem',
+                    cursor: 'pointer',
+                    padding: '0.2rem',
+                    lineHeight: 1
+                  }}
+                  onMouseEnter={(e) => { e.currentTarget.style.color = '#fbf1c7'; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.color = '#a89984'; }}
+                >
+                  ✎
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {editingMatch && (
+        <MatchEditorModal
+          match={editingMatch}
+          onClose={() => setEditingMatch(null)}
+          onSaved={handleMatchSaved}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/MatchEditorModal.tsx
+++ b/frontend/src/components/MatchEditorModal.tsx
@@ -1,0 +1,597 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import CharacterDisplay, { getCharacterIconUrl } from './CharacterDisplay';
+import { stageImages } from '../lib/stages';
+
+// Shape shared by /api/matches rows and /api/recent_games rows (the latter may
+// omit session_id/timestamp, hence optional).
+export interface EditableMatch {
+  match_id: string;
+  datetime: string;
+  shayne_character: string;
+  matt_character: string;
+  winner: string;
+  stage: string;
+  stocks_remaining: number | string | null;
+  session_id?: string;
+  timestamp?: string;
+}
+
+interface MatchUpdatePayload {
+  shayneCharacter?: string;
+  mattCharacter?: string;
+  winner?: string;
+  stage?: string;
+  stocksRemaining?: number | null;
+}
+
+interface ApiEnvelope {
+  success?: boolean;
+  message?: string;
+}
+
+interface CharactersResponse {
+  all_characters?: string[];
+}
+
+type Stocks = 1 | 2 | 3 | null;
+
+const SHAYNE_COLOR = '#fe8019';
+const MATT_COLOR = '#b8bb26';
+
+const normalizeStocks = (value: EditableMatch['stocks_remaining']): Stocks => {
+  if (value === null || value === undefined || value === '') return null;
+  const n = typeof value === 'number' ? value : Number(value);
+  return n === 1 || n === 2 || n === 3 ? (n as 1 | 2 | 3) : null;
+};
+
+const parseJson = async (res: Response): Promise<ApiEnvelope> => {
+  try {
+    return (await res.json()) as ApiEnvelope;
+  } catch {
+    throw new Error('Server returned an invalid response.');
+  }
+};
+
+const errorMessage = (err: unknown): string =>
+  err instanceof Error ? err.message : String(err);
+
+function CharacterPicker({ label, accent, value, onChange, roster }: {
+  label: string;
+  accent: string;
+  value: string;
+  onChange: (character: string) => void;
+  roster: string[];
+}) {
+  const [search, setSearch] = useState(value);
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Keep the input in sync if the value changes from outside
+  useEffect(() => {
+    setSearch(value);
+  }, [value]);
+
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setSearch(value);
+      }
+    };
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [value]);
+
+  const filtered = roster.filter(char =>
+    char.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const iconUrl = getCharacterIconUrl(value);
+
+  return (
+    <div ref={containerRef} style={{ position: 'relative', minWidth: 0 }}>
+      <div style={{
+        fontSize: '0.8rem',
+        fontWeight: 'bold',
+        color: accent,
+        marginBottom: '0.35rem',
+        textTransform: 'uppercase',
+        letterSpacing: '0.5px'
+      }}>
+        {label}
+      </div>
+      <div style={{ position: 'relative' }}>
+        {iconUrl && (
+          <img
+            src={iconUrl}
+            alt={value}
+            style={{
+              position: 'absolute',
+              left: '0.5rem',
+              top: '50%',
+              transform: 'translateY(-50%)',
+              width: '20px',
+              height: '20px',
+              objectFit: 'contain',
+              pointerEvents: 'none'
+            }}
+          />
+        )}
+        <input
+          type="text"
+          value={search}
+          placeholder="Search character..."
+          autoComplete="off"
+          onChange={e => {
+            setSearch(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          style={{
+            width: '100%',
+            boxSizing: 'border-box',
+            background: '#282828',
+            color: '#ebdbb2',
+            border: `1px solid ${open ? accent : '#504945'}`,
+            borderRadius: '6px',
+            padding: iconUrl ? '0.5rem 0.5rem 0.5rem 2.1rem' : '0.5rem',
+            fontSize: '0.85rem',
+            outline: 'none'
+          }}
+        />
+      </div>
+      {open && (
+        <div style={{
+          position: 'absolute',
+          top: '100%',
+          left: 0,
+          right: 0,
+          marginTop: '0.25rem',
+          maxHeight: '200px',
+          overflowY: 'auto',
+          background: '#282828',
+          border: '1px solid #504945',
+          borderRadius: '6px',
+          zIndex: 10,
+          boxShadow: '0 4px 12px rgba(0, 0, 0, 0.5)'
+        }}>
+          {filtered.length === 0 && (
+            <div style={{ padding: '0.5rem', fontSize: '0.8rem', color: '#a89984' }}>
+              No characters match.
+            </div>
+          )}
+          {filtered.map(char => (
+            <div
+              key={char}
+              onClick={() => {
+                onChange(char);
+                setSearch(char);
+                setOpen(false);
+              }}
+              style={{
+                padding: '0.4rem 0.5rem',
+                fontSize: '0.85rem',
+                cursor: 'pointer',
+                borderLeft: char === value ? `3px solid ${accent}` : '3px solid transparent'
+              }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = '#3c3836'; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+            >
+              <CharacterDisplay character={char} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export interface MatchEditorModalProps {
+  match: EditableMatch;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+function MatchEditorModal({ match, onClose, onSaved }: MatchEditorModalProps) {
+  const [roster, setRoster] = useState<string[]>([]);
+  const [shayneCharacter, setShayneCharacter] = useState(match.shayne_character);
+  const [mattCharacter, setMattCharacter] = useState(match.matt_character);
+  const [stage, setStage] = useState(match.stage || '');
+  const [winner, setWinner] = useState(match.winner);
+  const [stocks, setStocks] = useState<Stocks>(normalizeStocks(match.stocks_remaining));
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/characters')
+      .then(res => res.json())
+      .then((data: CharactersResponse) => {
+        if (!cancelled && Array.isArray(data.all_characters)) {
+          setRoster(data.all_characters);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setError('Failed to load character roster.');
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const originalStocks = useMemo(() => normalizeStocks(match.stocks_remaining), [match]);
+
+  const changes = useMemo<MatchUpdatePayload>(() => {
+    const payload: MatchUpdatePayload = {};
+    if (shayneCharacter !== match.shayne_character) payload.shayneCharacter = shayneCharacter;
+    if (mattCharacter !== match.matt_character) payload.mattCharacter = mattCharacter;
+    if (winner !== match.winner) payload.winner = winner;
+    if (stage !== (match.stage || '')) payload.stage = stage;
+    if (stocks !== originalStocks) payload.stocksRemaining = stocks;
+    return payload;
+  }, [shayneCharacter, mattCharacter, winner, stage, stocks, match, originalStocks]);
+
+  const hasChanges = Object.keys(changes).length > 0;
+  const inFlight = saving || deleting;
+
+  const handleSave = async () => {
+    if (!hasChanges || inFlight) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/matches/${encodeURIComponent(match.match_id)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(changes)
+      });
+      const data = await parseJson(res);
+      if (!res.ok || !data.success) throw new Error(data.message || 'Failed to save match.');
+      onSaved();
+      onClose();
+    } catch (err: unknown) {
+      setError(errorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (inFlight) return;
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    setDeleting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/matches/${encodeURIComponent(match.match_id)}`, {
+        method: 'DELETE'
+      });
+      const data = await parseJson(res);
+      if (!res.ok || !data.success) throw new Error(data.message || 'Failed to delete match.');
+      onSaved();
+      onClose();
+    } catch (err: unknown) {
+      setError(errorMessage(err));
+      setConfirmDelete(false);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const formatDateTime = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return date.toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit'
+    });
+  };
+
+  const sectionLabelStyle: React.CSSProperties = {
+    fontSize: '0.8rem',
+    fontWeight: 'bold',
+    color: '#a89984',
+    marginBottom: '0.5rem',
+    textTransform: 'uppercase',
+    letterSpacing: '0.5px'
+  };
+
+  const toggleButtonStyle = (selected: boolean, accent: string): React.CSSProperties => ({
+    padding: '0.5rem 0.75rem',
+    borderRadius: '6px',
+    border: `2px solid ${selected ? accent : '#504945'}`,
+    background: selected ? accent : 'transparent',
+    color: selected ? '#282828' : '#ebdbb2',
+    fontSize: '0.85rem',
+    fontWeight: 'bold',
+    cursor: 'pointer',
+    transition: 'all 0.15s'
+  });
+
+  const stageOptions = Object.keys(stageImages);
+
+  return (
+    <div
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0, 0, 0, 0.65)',
+        zIndex: 1000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '1rem'
+      }}
+    >
+      <div style={{
+        background: '#3c3836',
+        border: '1px solid #504945',
+        borderRadius: '12px',
+        padding: '1.25rem',
+        width: 'min(600px, 94vw)',
+        maxHeight: '90vh',
+        overflowY: 'auto',
+        boxShadow: '0 8px 32px rgba(0, 0, 0, 0.6)'
+      }}>
+        {/* Header */}
+        <div style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          marginBottom: '1rem'
+        }}>
+          <div>
+            <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#fbf1c7' }}>
+              Edit Match
+            </div>
+            <div style={{ fontSize: '0.75rem', color: '#a89984', marginTop: '0.2rem' }}>
+              {formatDateTime(match.datetime)}
+              {match.session_id ? ` · Session ${match.session_id}` : ''}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            style={{
+              background: 'none',
+              border: 'none',
+              color: '#a89984',
+              fontSize: '1.1rem',
+              cursor: 'pointer',
+              padding: '0.2rem',
+              lineHeight: 1
+            }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = '#fbf1c7'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = '#a89984'; }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Character pickers */}
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+          gap: '0.75rem',
+          marginBottom: '1rem'
+        }}>
+          <CharacterPicker
+            label="Shayne"
+            accent={SHAYNE_COLOR}
+            value={shayneCharacter}
+            onChange={setShayneCharacter}
+            roster={roster}
+          />
+          <CharacterPicker
+            label="Matt"
+            accent={MATT_COLOR}
+            value={mattCharacter}
+            onChange={setMattCharacter}
+            roster={roster}
+          />
+        </div>
+
+        {/* Stage */}
+        <div style={{ marginBottom: '1rem' }}>
+          <div style={sectionLabelStyle}>Stage</div>
+          <div style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(3, 1fr)',
+            gap: '0.5rem'
+          }}>
+            {stageOptions.map(s => {
+              const selected = stage === s;
+              return (
+                <button
+                  type="button"
+                  key={s}
+                  onClick={() => setStage(s)}
+                  style={{
+                    backgroundImage: `url(${stageImages[s]})`,
+                    backgroundSize: 'cover',
+                    backgroundPosition: 'center',
+                    position: 'relative',
+                    overflow: 'hidden',
+                    minHeight: '52px',
+                    padding: '0.4rem',
+                    borderRadius: '6px',
+                    border: `2px solid ${selected ? '#fabd2f' : '#504945'}`,
+                    cursor: 'pointer',
+                    color: '#fbf1c7'
+                  }}
+                >
+                  <div style={{
+                    position: 'absolute',
+                    inset: 0,
+                    backgroundColor: selected ? 'rgba(0, 0, 0, 0.35)' : 'rgba(0, 0, 0, 0.6)',
+                    zIndex: 1
+                  }} />
+                  <span style={{
+                    position: 'relative',
+                    zIndex: 2,
+                    fontSize: '0.7rem',
+                    fontWeight: 'bold',
+                    textShadow: '0 1px 3px rgba(0, 0, 0, 0.9)'
+                  }}>
+                    {s}
+                  </span>
+                </button>
+              );
+            })}
+            <button
+              type="button"
+              onClick={() => setStage('')}
+              style={{
+                minHeight: '52px',
+                padding: '0.4rem',
+                borderRadius: '6px',
+                border: `2px solid ${stage === '' ? '#fabd2f' : '#504945'}`,
+                background: '#282828',
+                color: stage === '' ? '#fbf1c7' : '#a89984',
+                fontSize: '0.7rem',
+                fontWeight: 'bold',
+                cursor: 'pointer'
+              }}
+            >
+              No Stage
+            </button>
+          </div>
+        </div>
+
+        {/* Winner + Stocks */}
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+          gap: '0.75rem',
+          marginBottom: '1rem'
+        }}>
+          <div>
+            <div style={sectionLabelStyle}>Winner</div>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              <button
+                type="button"
+                onClick={() => setWinner('Shayne')}
+                style={{ ...toggleButtonStyle(winner === 'Shayne', SHAYNE_COLOR), flex: 1 }}
+              >
+                Shayne
+              </button>
+              <button
+                type="button"
+                onClick={() => setWinner('Matt')}
+                style={{ ...toggleButtonStyle(winner === 'Matt', MATT_COLOR), flex: 1 }}
+              >
+                Matt
+              </button>
+            </div>
+          </div>
+          <div>
+            <div style={sectionLabelStyle}>Stocks Left</div>
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+              {([1, 2, 3] as const).map(n => (
+                <button
+                  type="button"
+                  key={n}
+                  onClick={() => setStocks(n)}
+                  style={{ ...toggleButtonStyle(stocks === n, '#83a598'), flex: 1 }}
+                >
+                  {n}
+                </button>
+              ))}
+              <button
+                type="button"
+                onClick={() => setStocks(null)}
+                title="No stocks recorded"
+                style={{ ...toggleButtonStyle(stocks === null, '#83a598'), flex: 1 }}
+              >
+                —
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {error && (
+          <div className="error" style={{ padding: '0.5rem', fontSize: '0.85rem', marginBottom: '0.75rem' }}>
+            {error}
+          </div>
+        )}
+
+        {/* Footer */}
+        <div style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+          gap: '0.5rem'
+        }}>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={inFlight}
+            style={{
+              padding: '0.5rem 1rem',
+              borderRadius: '6px',
+              border: '1px solid #665c54',
+              background: 'transparent',
+              color: '#ebdbb2',
+              fontSize: '0.85rem',
+              cursor: inFlight ? 'default' : 'pointer',
+              opacity: inFlight ? 0.6 : 1
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={inFlight}
+            style={{
+              padding: '0.5rem 1rem',
+              borderRadius: '6px',
+              border: '1px solid #fb4934',
+              background: confirmDelete ? '#fb4934' : 'transparent',
+              color: confirmDelete ? '#282828' : '#fb4934',
+              fontSize: '0.85rem',
+              fontWeight: 'bold',
+              cursor: inFlight ? 'default' : 'pointer',
+              opacity: inFlight ? 0.6 : 1
+            }}
+          >
+            {deleting ? 'Deleting...' : confirmDelete ? 'Really delete?' : 'Delete'}
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!hasChanges || inFlight}
+            style={{
+              padding: '0.5rem 1.25rem',
+              borderRadius: '6px',
+              border: 'none',
+              background: '#83a598',
+              color: '#282828',
+              fontSize: '0.85rem',
+              fontWeight: 'bold',
+              cursor: !hasChanges || inFlight ? 'default' : 'pointer',
+              opacity: !hasChanges || inFlight ? 0.5 : 1
+            }}
+          >
+            {saving ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MatchEditorModal;


### PR DESCRIPTION
## Summary

Adds the match editor planned and confirmed on 2026-07-14: edit a past match's characters, winner, stage, or stocks — or delete a bogus row — from Recent Matches or any session's match list. Built on a new stable `match_id` so the API survives the SQLite migration (ROADMAP P2) unchanged, and it ships the repo's **first backend test suite** (12 pytest tests, wired into CI).

## Data repair included

While designing match identity I found **218 legacy rows with no `timestamp`** (only `datetime` strings). Those rows were invisible to every timestamp-sorted code path — recent games, undo, session backfill. An idempotent startup repair pass now:
- assigns a `match_id` (uuid4 hex, 12 chars) to every row lacking one,
- derives the missing timestamps from `datetime` (US/Eastern).

⚠️ **First boot after deploying this rewrites the CSV once** (under the write lock, boot backup taken beforehand, 14-day volume snapshots on top). Subsequent boots are no-ops. Documented in docs/DEPLOY.md.

## Changes

**Backend** (`app.py`)
- `GET /api/matches` — paginated, newest-first, `session_id` filter (also powers the new session match list)
- `PUT /api/matches/<match_id>` — validated edits (roster / winner / stage / stocks 1–3-or-null; `""` stage canonicalizes to `"No Stage"`)
- `DELETE /api/matches/<match_id>`
- Every edit/delete appends before+after JSON to `/data/edit_log.csv` with the Basic-auth username as editor — cheap audit trail, recoverable deletes
- New matches get a `match_id` at log time

**Frontend**
- `MatchEditorModal`: character pickers, stage grid (includes Yoshi's Story for historical matches + No Stage), winner/stocks toggles, diff-only PUT, two-click delete confirm, Escape/backdrop close
- Recent Matches: ✎ per row
- Session detail: new Matches section listing every game in the session with ✎; aggregates re-fetch after edits

**Tests/CI**: `backend/tests/` (backfill correctness + idempotence, validation, 404s, audit log, delete semantics), `requirements-dev.txt`, pytest step added to the CI backend job.

## Verification

- [x] 12/12 pytest; tsc clean; lint 0 errors; vite build passes
- [x] E2E against a scratch copy of the real 3,197-row CSV: backfill produced 3,197 unique ids + 0 missing timestamps; PUT edit persisted (winner flip, stage canonicalization); invalid winner → 400; DELETE → 200 then 404; audit log recorded editor `matt` with full before-state
- [ ] Reviewer: log a throwaway match on the live app, edit it from Recent Matches, check it in a session view, delete it — then confirm `/data/edit_log.csv` recorded all three actions

## Deploy notes

`fly deploy` as usual. First boot logs `Backfill: filled 218 timestamps, 3197 match_ids` (one-time). Rollback is safe: the extra CSV column is ignored by older code.

Deliberately deferred (per plan): datetime/session edits, bulk edits, a browse-all-matches page.