### PR TITLE
Full dither-kit adoption: every chart on the dithered canvas engine, ECharts removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ players (Shayne vs Matt). A Flask API and a React (Vite) single-page app ship as
 one container, backed by CSV storage with session grouping and rich analytics.
 Roughly 3,200 historical matches are already logged.
 
-**Stack:** React 19 · react-router 6 · Vite 6 · TypeScript 5.8 · Recharts +
-[dither-kit](https://www.tripwire.sh/dither-kit) charts · Flask 3.1 · gunicorn ·
-pandas / numpy · deployed on Fly.io.
+**Stack:** React 19 · react-router 6 · Vite 6 · TypeScript 5.8 ·
+[dither-kit](https://www.tripwire.sh/dither-kit) charts (vendored, MIT) ·
+Flask 3.1 · gunicorn · pandas / numpy · deployed on Fly.io.
 
 ## System design
 
@@ -19,7 +19,7 @@ until real multi-user auth ships.
 ```mermaid
 flowchart TB
     subgraph client["Client — browser (Matt / Shayne)"]
-        SPA["React 19 SPA<br/>react-router · Recharts · dither-kit"]
+        SPA["React 19 SPA<br/>react-router · dither-kit charts"]
     end
 
     subgraph fly["Fly.io — single container · ewr · shared-cpu-1x 512MB"]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -154,7 +154,21 @@ leverage-per-effort:
 4. **Quick rematch** button repeating characters+stage in one tap (sticky
    stage + undo shipped; this is the last logger-ergonomics item).
 
-## 5. Dither-kit adoption plan
+## 5. Dither-kit adoption — SHIPPED 2026-07-14
+
+Fully adopted (no pilot): the kit is vendored at `frontend/src/components/dither/`
+(MIT, upstream commit `9fb0b14`) with Tailwind utilities replaced by a scoped
+`dither.css`, the palette retuned to Gruvbox seeds (orange=Shayne, green=Matt,
++ new yellow/aqua), and `cn()`/`process.env` adapted for a no-Tailwind Vite app.
+All 14 chart mounts across 8 pages converted; the three day×hour heatmaps use a
+local `DitherHeatmap` extension built on the kit's Bayer primitives. ECharts is
+removed: total JS ~1.6 MB → ~0.8 MB. Notable conversion calls: SessionHistory's
+rolling-average line became a stacked win-split bar; win-rate-bucket bar colors
+collapsed to single-series blue; markLines dropped (no primitive).
+
+Original plan follows for reference:
+
+### (superseded) adoption plan
 
 [dither-kit](https://www.tripwire.sh/dither-kit) (Boring Software Inc): dithered
 retro-aesthetic charts on a tiny canvas engine — area/sparkline, line, bar

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,13 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "echarts": "^6.0.0",
+        "@types/d3-scale": "^4.0.9",
+        "@types/d3-shape": "^3.1.8",
+        "clsx": "^2.1.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
         "html2canvas": "^1.4.1",
+        "motion": "^12.42.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^6.30.0"
@@ -1418,6 +1423,36 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1939,6 +1974,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2004,6 +2048,109 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2028,16 +2175,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/echarts": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
-      "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "2.3.0",
-        "zrender": "6.0.0"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.245",
@@ -2413,6 +2550,39 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/framer-motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.42.2",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/framer-motion/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2529,6 +2699,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -2731,6 +2910,53 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.42.2.tgz",
+      "integrity": "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.42.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT"
+    },
+    "node_modules/motion/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3253,12 +3479,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-      "license": "0BSD"
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3510,15 +3730,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zrender": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
-      "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tslib": "2.3.0"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,8 +10,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "echarts": "^6.0.0",
+    "@types/d3-scale": "^4.0.9",
+    "@types/d3-shape": "^3.1.8",
+    "clsx": "^2.1.1",
+    "d3-scale": "^4.0.2",
+    "d3-shape": "^3.2.0",
     "html2canvas": "^1.4.1",
+    "motion": "^12.42.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.0"

--- a/frontend/src/CharacterAnalytics.tsx
+++ b/frontend/src/CharacterAnalytics.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import * as echarts from 'echarts';
 import CharacterDisplay from './components/CharacterDisplay';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, type ChartConfig } from './components/dither';
 
 interface CharacterOverviewData {
   total_games: number;
@@ -23,14 +23,34 @@ interface CharactersStatsResponse {
   total_matches: number;
 }
 
+interface UsageChartRow {
+  name: string;
+  usage: number;
+  games: number;
+}
+
+interface WinRateBinRow {
+  range: string;
+  count: number;
+}
+
+const WIN_RATE_BINS = [0, 20, 40, 50, 60, 80, 100];
+const WIN_RATE_BIN_LABELS = ['0-20%', '20-40%', '40-50%', '50-60%', '60-80%', '80-100%'];
+
+const usageChartConfig: ChartConfig = {
+  usage: { label: 'Usage %', color: 'blue' },
+};
+
+const winRateDistConfig: ChartConfig = {
+  count: { label: 'Characters', color: 'blue' },
+};
+
 const CharacterAnalytics: React.FC = () => {
   const [data, setData] = useState<CharactersStatsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<'usage_rate' | 'win_rate' | 'total_games'>('usage_rate');
   const [filterMinGames, setFilterMinGames] = useState(0);
-  const usageChartRef = useRef<HTMLDivElement>(null);
-  const winRateDistRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -52,243 +72,33 @@ const CharacterAnalytics: React.FC = () => {
     fetchData();
   }, []);
 
-  // ECharts visualizations
-  useEffect(() => {
-    if (!data) return;
+  // Top 15 characters by usage rate
+  const usageChartData: UsageChartRow[] = data
+    ? Object.entries(data.characters)
+        .filter(([, stats]) => stats.total_games > 0)
+        .sort((a, b) => b[1].usage_rate - a[1].usage_rate)
+        .slice(0, 15)
+        .map(([name, stats]) => ({
+          name,
+          usage: stats.usage_rate,
+          games: stats.total_games,
+        }))
+    : [];
 
-    const activeChars = Object.entries(data.characters)
-      .filter(([_, stats]) => stats.total_games > 0)
-      .sort((a, b) => b[1].usage_rate - a[1].usage_rate)
-      .slice(0, 15);
-
-    // Usage Distribution Chart
-    if (usageChartRef.current) {
-      const chart = echarts.init(usageChartRef.current);
-      
-      chart.setOption({
-        backgroundColor: 'transparent',
-        tooltip: {
-          trigger: 'axis',
-          axisPointer: { 
-            type: 'shadow',
-            shadowStyle: {
-              color: 'rgba(131, 165, 152, 0.1)'
-            }
-          },
-          backgroundColor: '#3c3836',
-          borderColor: '#83a598',
-          borderWidth: 2,
-          textStyle: { color: '#ebdbb2', fontSize: 12 },
-          padding: 12,
-          formatter: (params: any) => {
-            const p = params[0];
-            const charData = activeChars[p.dataIndex];
-            const games = charData[1].total_games;
-            return `<div style="font-weight: bold; margin-bottom: 4px;">${p.name}</div>` +
-                   `<div style="color: #83a598;">Usage: ${p.value.toFixed(1)}%</div>` +
-                   `<div style="color: #a89984; font-size: 11px;">${games} games</div>`;
-          }
-        },
-        grid: { left: '3%', right: '4%', top: '8%', bottom: '25%', containLabel: true },
-        xAxis: {
-          type: 'category',
-          data: activeChars.map(([name]) => name),
-          axisLine: { lineStyle: { color: '#504945', width: 2 } },
-          axisLabel: { 
-            color: '#a89984', 
-            fontSize: 9, 
-            rotate: 45,
-            interval: 0,
-            fontWeight: 500
-          },
-          axisTick: {
-            show: true,
-            lineStyle: { color: '#504945' }
-          }
-        },
-        yAxis: {
-          type: 'value',
-          axisLine: { show: true, lineStyle: { color: '#504945', width: 2 } },
-          axisLabel: { 
-            color: '#a89984', 
-            fontSize: 10, 
-            formatter: '{value}%',
-            fontWeight: 500
-          },
-          splitLine: { 
-            lineStyle: { 
-              color: '#3c3836', 
-              type: 'dashed',
-              width: 1
-            } 
-          }
-        },
-        series: [{
-          data: activeChars.map(([_, stats]) => stats.usage_rate),
-          type: 'bar',
-          itemStyle: {
-            color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-              { offset: 0, color: '#83a598' },
-              { offset: 0.5, color: '#689d6a' },
-              { offset: 1, color: '#458588' }
-            ]),
-            borderRadius: [4, 4, 0, 0],
-            shadowColor: 'rgba(131, 165, 152, 0.3)',
-            shadowBlur: 8,
-            shadowOffsetY: 2
-          },
-          emphasis: {
-            itemStyle: {
-              color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-                { offset: 0, color: '#8ec07c' },
-                { offset: 0.5, color: '#83a598' },
-                { offset: 1, color: '#689d6a' }
-              ]),
-              shadowColor: 'rgba(131, 165, 152, 0.5)',
-              shadowBlur: 12,
-              shadowOffsetY: 4
-            }
-          },
-          barWidth: '65%',
-          animationDelay: (idx: number) => idx * 30
-        }]
-      });
-
-      const resizeObserver = new ResizeObserver(() => chart.resize());
-      resizeObserver.observe(usageChartRef.current);
-
-      return () => {
-        resizeObserver.disconnect();
-        chart.dispose();
-      };
-    }
-  }, [data]);
-
-  useEffect(() => {
-    if (!data) return;
-
-    const activeChars = Object.entries(data.characters)
-      .filter(([_, stats]) => stats.total_games > 0);
-
-    // Win Rate Distribution
-    if (winRateDistRef.current) {
-      const chart = echarts.init(winRateDistRef.current);
-      
-      const bins = [0, 20, 40, 50, 60, 80, 100];
-      const binCounts = new Array(bins.length - 1).fill(0);
-      
-      activeChars.forEach(([_, stats]) => {
-        for (let i = 0; i < bins.length - 1; i++) {
-          if (stats.win_rate >= bins[i] && stats.win_rate < bins[i + 1]) {
-            binCounts[i]++;
-            break;
-          }
-        }
-      });
-
-      chart.setOption({
-        backgroundColor: 'transparent',
-        tooltip: {
-          trigger: 'axis',
-          axisPointer: { 
-            type: 'shadow',
-            shadowStyle: {
-              color: 'rgba(251, 73, 52, 0.1)'
-            }
-          },
-          backgroundColor: '#3c3836',
-          borderColor: '#fe8019',
-          borderWidth: 2,
-          textStyle: { color: '#ebdbb2', fontSize: 12 },
-          padding: 12,
-          formatter: (params: any) => {
-            const p = params[0];
-            const range = p.name;
-            const count = p.value;
-            const total = binCounts.reduce((a: number, b: number) => a + b, 0);
-            const percent = ((count / total) * 100).toFixed(1);
-            return `<div style="font-weight: bold; margin-bottom: 4px;">${range} Win Rate</div>` +
-                   `<div style="color: #fe8019;">${count} characters (${percent}%)</div>`;
-          }
-        },
-        grid: { left: '8%', right: '4%', top: '8%', bottom: '15%', containLabel: true },
-        xAxis: {
-          type: 'category',
-          data: ['0-20%', '20-40%', '40-50%', '50-60%', '60-80%', '80-100%'],
-          axisLine: { lineStyle: { color: '#504945', width: 2 } },
-          axisLabel: { 
-            color: '#a89984', 
-            fontSize: 10,
-            fontWeight: 500
-          },
-          axisTick: {
-            show: true,
-            lineStyle: { color: '#504945' }
-          }
-        },
-        yAxis: {
-          type: 'value',
-          axisLine: { show: true, lineStyle: { color: '#504945', width: 2 } },
-          axisLabel: { 
-            color: '#a89984', 
-            fontSize: 10,
-            fontWeight: 500
-          },
-          splitLine: { 
-            lineStyle: { 
-              color: '#3c3836', 
-              type: 'dashed',
-              width: 1
-            } 
-          }
-        },
-        series: [{
-          data: binCounts,
-          type: 'bar',
-          itemStyle: {
-            color: (params: any) => {
-              const colors = [
-                { start: '#fb4934', end: '#cc241d' },
-                { start: '#fabd2f', end: '#d79921' },
-                { start: '#fe8019', end: '#d65d0e' },
-                { start: '#b8bb26', end: '#98971a' },
-                { start: '#8ec07c', end: '#689d6a' },
-                { start: '#83a598', end: '#458588' }
-              ];
-              const colorPair = colors[params.dataIndex];
-              return new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-                { offset: 0, color: colorPair.start },
-                { offset: 1, color: colorPair.end }
-              ]);
-            },
-            borderRadius: [4, 4, 0, 0],
-            shadowColor: 'rgba(0, 0, 0, 0.3)',
-            shadowBlur: 8,
-            shadowOffsetY: 2
-          },
-          emphasis: {
-            itemStyle: {
-              shadowColor: 'rgba(0, 0, 0, 0.5)',
-              shadowBlur: 12,
-              shadowOffsetY: 4,
-              borderColor: '#ebdbb2',
-              borderWidth: 2
-            }
-          },
-          barWidth: '75%',
-          animationDelay: (idx: number) => idx * 50
-        }]
-      });
-
-      const resizeObserver = new ResizeObserver(() => chart.resize());
-      resizeObserver.observe(winRateDistRef.current);
-
-      return () => {
-        resizeObserver.disconnect();
-        chart.dispose();
-      };
-    }
-  }, [data]);
+  // Win rate distribution across bins (last bin inclusive of 100%)
+  const winRateDistData: WinRateBinRow[] = data
+    ? WIN_RATE_BIN_LABELS.map((range, i) => ({
+        range,
+        count: Object.values(data.characters).filter(
+          (stats) =>
+            stats.total_games > 0 &&
+            stats.win_rate >= WIN_RATE_BINS[i] &&
+            (i === WIN_RATE_BIN_LABELS.length - 1
+              ? stats.win_rate <= WIN_RATE_BINS[i + 1]
+              : stats.win_rate < WIN_RATE_BINS[i + 1])
+        ).length,
+      }))
+    : [];
 
   if (loading) {
     return (
@@ -426,11 +236,25 @@ const CharacterAnalytics: React.FC = () => {
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(400px, 1fr))', gap: '1rem', marginBottom: '1rem' }}>
           <div className="card" style={{ padding: '1rem' }}>
             <h3 style={{ fontSize: '1rem', marginBottom: '0.75rem', color: '#fbf1c7' }}>📊 Top 15 by Usage</h3>
-            <div ref={usageChartRef} style={{ height: '220px', width: '100%' }}></div>
+            <div style={{ height: '220px', width: '100%' }}>
+              <BarChart data={usageChartData} config={usageChartConfig}>
+                <XAxis dataKey="name" tickFormatter={(value) => String(value).split(' ')[0]} />
+                <YAxis tickFormatter={(value) => `${value}%`} />
+                <Tooltip labelKey="name" />
+                <Bar dataKey="usage" variant="gradient" />
+              </BarChart>
+            </div>
           </div>
           <div className="card" style={{ padding: '1rem' }}>
             <h3 style={{ fontSize: '1rem', marginBottom: '0.75rem', color: '#fbf1c7' }}>📈 Win Rate Distribution</h3>
-            <div ref={winRateDistRef} style={{ height: '220px', width: '100%' }}></div>
+            <div style={{ height: '220px', width: '100%' }}>
+              <BarChart data={winRateDistData} config={winRateDistConfig}>
+                <XAxis dataKey="range" />
+                <YAxis />
+                <Tooltip labelKey="range" />
+                <Bar dataKey="count" variant="gradient" />
+              </BarChart>
+            </div>
           </div>
         </div>
 

--- a/frontend/src/CharacterDetail.tsx
+++ b/frontend/src/CharacterDetail.tsx
@@ -1,10 +1,20 @@
-import React, { useCallback, useEffect, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import * as echarts from 'echarts';
 import CharacterDisplay from './components/CharacterDisplay';
 import { PerformanceHeatmap } from './components/PerformanceHeatmap';
 import { LoadingState, ErrorState } from './components/Feedback';
 import { stageImages } from './lib/stages';
+import {
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Legend,
+  Tooltip,
+  type ChartConfig,
+} from './components/dither';
 
 interface MatchupData {
   opponent: string;
@@ -55,6 +65,40 @@ interface TimelineData {
   games: number;
 }
 
+interface MatchupChartRow {
+  opponent: string;
+  winRate: number;
+  games: number;
+  wins: number;
+  losses: number;
+}
+
+interface PlayerComparisonRow {
+  metric: string;
+  shayne: number;
+  matt: number;
+}
+
+interface TimelineChartRow {
+  date: string;
+  games: number;
+  trend: number;
+}
+
+const matchupChartConfig: ChartConfig = {
+  winRate: { label: 'Win Rate %', color: 'blue' },
+};
+
+const playerComparisonConfig: ChartConfig = {
+  shayne: { label: 'Shayne', color: 'orange' },
+  matt: { label: 'Matt', color: 'green' },
+};
+
+const timelineChartConfig: ChartConfig = {
+  games: { label: 'Games', color: 'aqua' },
+  trend: { label: 'Trend', color: 'yellow' },
+};
+
 const CharacterDetail: React.FC = () => {
   const { character } = useParams<{ character: string }>();
   const [data, setData] = useState<CharacterStatsData | null>(null);
@@ -63,9 +107,6 @@ const CharacterDetail: React.FC = () => {
   const [heatmapData, setHeatmapData] = useState<any>(null);
   const [usingSimulatedHeatmap, setUsingSimulatedHeatmap] = useState(false);
   const [timelineData, setTimelineData] = useState<TimelineData[]>([]);
-  const matchupRadarRef = useRef<HTMLDivElement>(null);
-  const playerComparisonRef = useRef<HTMLDivElement>(null);
-  const timelineChartRef = useRef<HTMLDivElement>(null);
 
   const fetchData = useCallback(async () => {
     if (!character) return;
@@ -135,338 +176,47 @@ const CharacterDetail: React.FC = () => {
     fetchTimelineData();
   }, [character]);
 
-  // ECharts visualizations
-  useEffect(() => {
-    if (!data) return;
+  // Top matchups (12+ games), deduped and sorted by games played
+  const matchupChartData: MatchupChartRow[] = data
+    ? Array.from(
+        new Map(
+          [...data.best_matchups, ...data.worst_matchups]
+            .filter(m => m.games >= 12)
+            .map(m => [m.opponent, m])
+        ).values()
+      )
+        .sort((a, b) => b.games - a.games)
+        .slice(0, 10)
+        .map(m => ({
+          opponent: m.opponent,
+          winRate: Math.round(m.win_rate),
+          games: m.games,
+          wins: m.wins,
+          losses: m.losses,
+        }))
+    : [];
 
-    // Top Matchups Bar Chart - Only matchups with 12+ games
-    if (matchupRadarRef.current) {
-      const chart = echarts.init(matchupRadarRef.current);
-      
-      // Combine all matchups and filter for 12+ games
-      const allMatchups = [
-        ...data.best_matchups.filter(m => m.games >= 12),
-        ...data.worst_matchups.filter(m => m.games >= 12)
-      ];
-      
-      // Remove duplicates and sort by total games
-      const uniqueMatchups = Array.from(
-        new Map(allMatchups.map(m => [m.opponent, m])).values()
-      ).sort((a, b) => b.games - a.games).slice(0, 10);
-      
-      if (uniqueMatchups.length === 0) {
-        // Show message if no significant matchups
-        chart.setOption({
-          backgroundColor: 'transparent',
-          title: {
-            text: 'Not enough data\n(12+ games needed per matchup)',
-            left: 'center',
-            top: 'center',
-            textStyle: {
-              color: '#a89984',
-              fontSize: 12,
-              fontStyle: 'italic'
-            }
-          }
-        });
-      } else {
-        chart.setOption({
-          backgroundColor: 'transparent',
-          tooltip: {
-            trigger: 'axis',
-            axisPointer: { type: 'shadow' },
-            backgroundColor: '#3c3836',
-            borderColor: '#504945',
-            borderWidth: 2,
-            textStyle: { color: '#ebdbb2', fontSize: 11 },
-            formatter: (params: any) => {
-              const matchup = uniqueMatchups[params[0].dataIndex];
-              return `<div style="font-weight: bold; margin-bottom: 4px;">${matchup.opponent}</div>` +
-                     `<div style="color: ${matchup.win_rate >= 50 ? '#b8bb26' : '#fb4934'};">Win Rate: ${Math.round(matchup.win_rate)}%</div>` +
-                     `<div style="color: #a89984; font-size: 10px;">Record: ${matchup.wins}W-${matchup.losses}L</div>` +
-                     `<div style="color: #83a598; font-size: 10px;">${matchup.games} games played</div>`;
-            }
-          },
-          grid: { 
-            left: '20%', 
-            right: '8%', 
-            top: '5%', 
-            bottom: '5%', 
-            containLabel: false
-          },
-          xAxis: {
-            type: 'value',
-            max: 100,
-            axisLine: { show: false },
-            axisTick: { show: false },
-            axisLabel: { 
-              color: '#a89984',
-              fontSize: 9,
-              formatter: '{value}%'
-            },
-            splitLine: {
-              lineStyle: { color: '#3c3836', type: 'dashed' } 
-            }
-          },
-          yAxis: {
-            type: 'category',
-            data: uniqueMatchups.map(m => m.opponent),
-            axisLine: { show: false },
-            axisTick: { show: false },
-            axisLabel: { 
-              color: '#ebdbb2', 
-              fontSize: 10,
-              fontWeight: 500
-            },
-            inverse: true
-          },
-          series: [{
-            type: 'bar',
-            data: uniqueMatchups.map(matchup => ({
-              value: matchup.win_rate,
-              itemStyle: {
-                color: matchup.win_rate >= 60 ? '#b8bb26' : 
-                       matchup.win_rate >= 50 ? '#83a598' : 
-                       matchup.win_rate >= 40 ? '#fe8019' : '#fb4934',
-                borderRadius: [0, 4, 4, 0]
-              }
-            })),
-            barMaxWidth: 20,
-            label: {
-              show: true,
-              position: 'right',
-              formatter: (params: any) => {
-                const matchup = uniqueMatchups[params.dataIndex];
-                return `${Math.round(matchup.win_rate)}% (${matchup.games}g)`;
-              },
-              color: '#ebdbb2',
-              fontSize: 10,
-              fontWeight: 'bold'
-            },
-            emphasis: {
-              itemStyle: {
-                shadowBlur: 10,
-                shadowColor: 'rgba(0, 0, 0, 0.5)'
-              }
-              }
-          }]
-        });
-      }
-
-      const resizeObserver = new ResizeObserver(() => chart.resize());
-      resizeObserver.observe(matchupRadarRef.current);
-
-      return () => {
-        resizeObserver.disconnect();
-        chart.dispose();
-      };
-    }
-  }, [data]);
-
-  useEffect(() => {
-    if (!data) return;
-
-    // Player Comparison Chart
-    if (playerComparisonRef.current) {
-      const chart = echarts.init(playerComparisonRef.current);
-
-      chart.setOption({
-        backgroundColor: 'transparent',
-        tooltip: {
-          trigger: 'axis',
-          axisPointer: { type: 'shadow' },
-          backgroundColor: '#3c3836',
-          borderColor: '#504945',
-          textStyle: { color: '#ebdbb2' }
-        },
-        legend: {
-          data: ['Shayne', 'Matt'],
-          textStyle: { color: '#a89984' },
-          top: 0
-        },
-        grid: { left: '8%', right: '4%', top: '15%', bottom: '10%', containLabel: true },
-        xAxis: {
-          type: 'category',
-          data: ['Games', 'Wins', 'Win Rate'],
-          axisLine: { lineStyle: { color: '#504945' } },
-          axisLabel: { color: '#a89984', fontSize: 10 }
-        },
-        yAxis: {
-          type: 'value',
-          axisLine: { lineStyle: { color: '#504945' } },
-          axisLabel: { color: '#a89984', fontSize: 10 },
-          splitLine: { lineStyle: { color: '#3c3836', type: 'dashed' } }
-        },
-        series: [
-          {
-            name: 'Shayne',
-            type: 'bar',
-            data: [data.shayne_stats.games, data.shayne_stats.wins, data.shayne_stats.win_rate],
-            itemStyle: { color: '#fe8019' }
-          },
-          {
-            name: 'Matt',
-            type: 'bar',
-            data: [data.matt_stats.games, data.matt_stats.wins, data.matt_stats.win_rate],
-            itemStyle: { color: '#b8bb26' }
-          }
-        ]
-      });
-
-      const resizeObserver = new ResizeObserver(() => chart.resize());
-      resizeObserver.observe(playerComparisonRef.current);
-
-      return () => {
-        resizeObserver.disconnect();
-        chart.dispose();
-      };
-    }
-  }, [data]);
-
-
-  // Timeline Chart - Games per session
-  useEffect(() => {
-    if (!timelineData || timelineData.length === 0) return;
-    if (!timelineChartRef.current) return;
-
-    const chart = echarts.init(timelineChartRef.current);
-
-    // Format dates for display
-    const dates = timelineData.map(d => {
-      const date = new Date(d.datetime);
-      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-    });
-    const games = timelineData.map(d => d.games);
-
-    // Calculate rolling average (window of 5 sessions)
-    const rollingAvg: number[] = [];
-    const window = Math.min(5, Math.ceil(timelineData.length / 10)); // Adaptive window
-    for (let i = 0; i < games.length; i++) {
-      const start = Math.max(0, i - Math.floor(window / 2));
-      const end = Math.min(games.length, i + Math.ceil(window / 2));
-      const slice = games.slice(start, end);
-      const avg = slice.reduce((sum, val) => sum + val, 0) / slice.length;
-      rollingAvg.push(parseFloat(avg.toFixed(1)));
-    }
-      
-      chart.setOption({
-        backgroundColor: 'transparent',
-        tooltip: {
-          trigger: 'axis',
-        axisPointer: { type: 'cross' },
-          backgroundColor: '#3c3836',
-          borderColor: '#504945',
-        borderWidth: 2,
-          textStyle: { color: '#ebdbb2', fontSize: 11 },
-          formatter: (params: any) => {
-          const dataIndex = params[0].dataIndex;
-          const session = timelineData[dataIndex];
-          const date = new Date(session.datetime);
-          const formattedDate = date.toLocaleDateString('en-US', { 
-            month: 'short', 
-            day: 'numeric',
-            year: 'numeric'
-          });
-          let tooltip = `<div style="font-weight: bold; margin-bottom: 4px;">${formattedDate}</div>`;
-          
-          params.forEach((param: any) => {
-            if (param.seriesName === 'Games') {
-              tooltip += `<div style="color: #689d6a;">Games: ${param.value}</div>`;
-            } else if (param.seriesName === 'Trend') {
-              tooltip += `<div style="color: #fabd2f;">Avg: ${param.value}</div>`;
-            }
-          });
-          
-          tooltip += `<div style="color: #a89984; font-size: 10px;">Session ${session.session_id}</div>`;
-          return tooltip;
-        }
-      },
-      legend: {
-        data: ['Games', 'Trend'],
-        textStyle: { color: '#a89984', fontSize: 11 },
-        top: 0,
-        right: '8%'
-      },
-        grid: { 
-        left: '8%', 
-          right: '8%', 
-        top: '15%', 
-        bottom: timelineData.length > 20 ? '20%' : '15%',
-          containLabel: true 
-        },
-        xAxis: {
-        type: 'category',
-        data: dates,
-        axisLine: { lineStyle: { color: '#504945', width: 2 } },
-          axisLabel: { 
-            color: '#a89984', 
-            fontSize: 9,
-          rotate: timelineData.length > 20 ? 45 : 0,
-          interval: timelineData.length > 30 ? Math.floor(timelineData.length / 20) : 0
-          },
-        axisTick: { lineStyle: { color: '#504945' } }
-        },
-        yAxis: {
-        type: 'value',
-        axisLine: { show: true, lineStyle: { color: '#504945', width: 2 } },
-        axisLabel: { color: '#a89984', fontSize: 10 },
-        splitLine: { lineStyle: { color: '#3c3836', type: 'dashed' } }
-      },
-      series: [
-        {
-          name: 'Games',
-          data: games,
-          type: 'bar',
-            itemStyle: {
-            color: '#689d6a',
-            borderRadius: [4, 4, 0, 0]
-          },
-          emphasis: {
-            itemStyle: {
-              color: '#8ec07c'
-            }
-          },
-          barWidth: '60%',
-          animationDelay: (idx: number) => idx * 20
-        },
-        {
-          name: 'Trend',
-          data: rollingAvg,
-          type: 'line',
-          smooth: true,
-          symbol: 'circle',
-          symbolSize: 6,
-          lineStyle: {
-            color: '#fabd2f',
-            width: 3
-          },
-          itemStyle: {
-            color: '#fabd2f',
-            borderColor: '#d79921',
-            borderWidth: 2
-          },
-          emphasis: {
-            itemStyle: {
-              color: '#fabd2f',
-              borderColor: '#d79921',
-              borderWidth: 3,
-              shadowBlur: 10,
-              shadowColor: 'rgba(250, 189, 47, 0.5)'
-            }
-          },
-          z: 10
-        }
+  const playerComparisonData: PlayerComparisonRow[] = data
+    ? [
+        { metric: 'Games', shayne: data.shayne_stats.games, matt: data.matt_stats.games },
+        { metric: 'Wins', shayne: data.shayne_stats.wins, matt: data.matt_stats.wins },
+        { metric: 'Win Rate', shayne: data.shayne_stats.win_rate, matt: data.matt_stats.win_rate },
       ]
-      });
+    : [];
 
-      const resizeObserver = new ResizeObserver(() => chart.resize());
-      resizeObserver.observe(timelineChartRef.current);
-
-      return () => {
-        resizeObserver.disconnect();
-        chart.dispose();
-      };
-  }, [timelineData]);
+  // Games per session plus adaptive rolling average trend
+  const timelineWindow = Math.min(5, Math.ceil(timelineData.length / 10));
+  const timelineChartData: TimelineChartRow[] = timelineData.map((d, i) => {
+    const start = Math.max(0, i - Math.floor(timelineWindow / 2));
+    const end = Math.min(timelineData.length, i + Math.ceil(timelineWindow / 2));
+    const slice = timelineData.slice(start, end);
+    const avg = slice.reduce((sum, s) => sum + s.games, 0) / slice.length;
+    return {
+      date: new Date(d.datetime).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+      games: d.games,
+      trend: Number(avg.toFixed(1)),
+    };
+  });
 
   if (loading) {
     return (
@@ -618,11 +368,42 @@ const CharacterDetail: React.FC = () => {
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(350px, 1fr))', gap: '1rem', marginBottom: '1rem' }}>
         <div className="card" style={{ padding: '1rem' }}>
           <h3 style={{ fontSize: '1rem', marginBottom: '0.75rem', color: '#fbf1c7' }}>📊 Player Comparison</h3>
-          <div ref={playerComparisonRef} style={{ height: '220px', width: '100%' }}></div>
+          <div style={{ height: '220px', width: '100%' }}>
+            <BarChart data={playerComparisonData} config={playerComparisonConfig}>
+              <XAxis dataKey="metric" />
+              <YAxis />
+              <Legend isClickable />
+              <Tooltip labelKey="metric" />
+              <Bar dataKey="shayne" variant="gradient" />
+              <Bar dataKey="matt" variant="gradient" />
+            </BarChart>
+          </div>
         </div>
         <div className="card" style={{ padding: '1rem' }}>
           <h3 style={{ fontSize: '1rem', marginBottom: '0.75rem', color: '#fbf1c7' }}>🎯 Top Matchups</h3>
-          <div ref={matchupRadarRef} style={{ height: '220px', width: '100%' }}></div>
+          <div style={{ height: '220px', width: '100%' }}>
+            {matchupChartData.length > 0 ? (
+              <BarChart data={matchupChartData} config={matchupChartConfig}>
+                <XAxis dataKey="opponent" tickFormatter={(value) => String(value).split(' ')[0]} />
+                <YAxis tickFormatter={(value) => `${value}%`} />
+                <Tooltip labelKey="opponent" />
+                <Bar dataKey="winRate" variant="gradient" />
+              </BarChart>
+            ) : (
+              <div style={{
+                height: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: '#a89984',
+                fontSize: '0.8rem',
+                fontStyle: 'italic',
+                textAlign: 'center'
+              }}>
+                Not enough data<br />(12+ games needed per matchup)
+              </div>
+            )}
+          </div>
         </div>
       </div>
 
@@ -927,7 +708,16 @@ const CharacterDetail: React.FC = () => {
           }}>
             Games played with {character} across {timelineData.length} session{timelineData.length !== 1 ? 's' : ''}
           </div>
-          <div ref={timelineChartRef} style={{ height: '300px', width: '100%' }}></div>
+          <div style={{ height: '300px', width: '100%' }}>
+            <LineChart data={timelineChartData} config={timelineChartConfig}>
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Legend isClickable />
+              <Tooltip labelKey="date" />
+              <Line dataKey="games" variant="gradient" />
+              <Line dataKey="trend" strokeVariant="dashed" />
+            </LineChart>
+          </div>
         </div>
       )}
 

--- a/frontend/src/PlayerTearsheet.tsx
+++ b/frontend/src/PlayerTearsheet.tsx
@@ -1,8 +1,18 @@
 import { useCallback, useEffect, useState, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import html2canvas from 'html2canvas';
-import * as echarts from 'echarts';
 import CharacterDisplay from './components/CharacterDisplay';
+import {
+  ActiveDot,
+  DitherHeatmap,
+  Line,
+  LineChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+  type DitherColor,
+  type DitherHeatmapCell,
+} from './components/dither';
 import { LoadingState, ErrorState } from './components/Feedback';
 import { stageImages } from './lib/stages';
 
@@ -89,6 +99,12 @@ interface HeatmapData {
   total_games: number;
 }
 
+interface TimelineRow {
+  game: string;
+  label: string;
+  winRate: number;
+}
+
 function PlayerTearsheet() {
   const [searchParams] = useSearchParams();
   const username = searchParams.get('username') || 'Shayne';
@@ -100,12 +116,11 @@ function PlayerTearsheet() {
   const [error, setError] = useState<string | null>(null);
   const [generating, setGenerating] = useState(false);
   const tearsheetRef = useRef<HTMLDivElement>(null);
-  const winRateTimelineRef = useRef<HTMLDivElement>(null);
-  const performanceHeatmapRef = useRef<HTMLDivElement>(null);
 
-  // Determine player colors
+  // Determine player colors (hex for text styling, palette name for charts)
   const playerColor = username === 'Shayne' ? '#fe8019' : '#b8bb26';
   const opponentColor = username === 'Shayne' ? '#b8bb26' : '#fe8019';
+  const playerChartColor: DitherColor = username === 'Shayne' ? 'orange' : 'green';
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -139,248 +154,25 @@ function PlayerTearsheet() {
     fetchData();
   }, [fetchData]);
 
-  // Initialize Win Rate Timeline Chart
-  useEffect(() => {
-    if (!data || !winRateTimelineRef.current) return;
+  // Chart data — dither-kit rows (handle both nested and flat timeline shapes)
+  const timelineInfo = timelineData?.data ?? timelineData;
+  const timelineRows: TimelineRow[] =
+    timelineInfo?.game_numbers && timelineInfo.win_rates
+      ? timelineInfo.game_numbers.map((n, i) => ({
+          game: `${n}`,
+          label: timelineInfo.date_ranges?.[i] ?? `Window ${n}`,
+          winRate: timelineInfo.win_rates?.[i] ?? 0,
+        }))
+      : [];
 
-    const chart = echarts.init(winRateTimelineRef.current);
-    
-    let xData: string[];
-    let yData: number[];
-    let dateRanges: string[] = [];
-    
-    // Handle both nested and flat data structures
-    const timelineInfo = timelineData?.data || timelineData;
-    
-    if (timelineInfo && timelineInfo.game_numbers && timelineInfo.win_rates) {
-      xData = timelineInfo.game_numbers.map((n: number) => `${n}`);
-      yData = timelineInfo.win_rates;
-      dateRanges = timelineInfo.date_ranges || [];
-    } else {
-      // Fallback to empty data
-      xData = [];
-      yData = [];
-    }
-
-    chart.setOption({
-      backgroundColor: 'transparent',
-      tooltip: {
-        trigger: 'axis',
-        backgroundColor: '#3c3836',
-        borderColor: '#504945',
-        textStyle: { color: '#ebdbb2', fontSize: 11 },
-        formatter: (params: any) => {
-          const point = params[0];
-          const windowIndex = point.dataIndex;
-          let tooltip = `20-Game Win Rate: ${point.value.toFixed(1)}%`;
-          
-          if (dateRanges.length > windowIndex) {
-            tooltip += `<br/>Period: ${dateRanges[windowIndex]}`;
-          }
-          
-          return tooltip;
-        }
-      },
-      grid: { left: '8%', right: '8%', top: '12%', bottom: '15%', containLabel: true },
-      xAxis: {
-        type: 'category',
-        data: xData,
-        axisLine: { lineStyle: { color: '#504945' } },
-        axisLabel: { color: '#a89984', fontSize: 9, interval: Math.floor(xData.length / 10) },
-        name: '20-Game Windows',
-        nameTextStyle: { color: '#a89984', fontSize: 10 },
-        nameLocation: 'middle',
-        nameGap: 25
-      },
-      yAxis: {
-        type: 'value',
-        axisLine: { lineStyle: { color: '#504945' } },
-        axisLabel: { color: '#a89984', fontSize: 9, formatter: '{value}%' },
-        splitLine: { lineStyle: { color: '#3c3836', type: 'dashed' } },
-        min: 0,
-        max: 100
-      },
-      series: [{
-        data: yData,
-        type: 'line',
-        smooth: true,
-        symbol: 'none',
-        lineStyle: { color: playerColor, width: 2 },
-        areaStyle: {
-          color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-            { offset: 0, color: username === 'Shayne' ? 'rgba(254, 128, 25, 0.3)' : 'rgba(184, 187, 38, 0.3)' },
-            { offset: 1, color: 'rgba(60, 56, 54, 0.1)' }
-          ])
-        },
-        markLine: {
-          silent: true,
-          symbol: 'none',
-          data: [
-            {
-              yAxis: 50,
-              lineStyle: { color: 'rgba(168, 153, 132, 0.2)', type: 'dashed', width: 1 },
-              label: { show: false }
-            },
-            {
-              yAxis: data.overall_stats.win_rate,
-              lineStyle: { color: '#83a598', type: 'solid', width: 1 },
-              label: { formatter: 'Overall: {c}%', color: '#83a598', fontSize: 9 }
-            }
-          ]
-        }
-      }]
-    });
-
-    const resizeObserver = new ResizeObserver(() => chart.resize());
-    resizeObserver.observe(winRateTimelineRef.current);
-
-    return () => {
-      resizeObserver.disconnect();
-      chart.dispose();
-    };
-  }, [data, timelineData, username, playerColor]);
-
-  // Initialize Performance Heatmap
-  useEffect(() => {
-    if (!data || !performanceHeatmapRef.current) return;
-
-    const chart = echarts.init(performanceHeatmapRef.current);
-    
-    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-    const hours = Array.from({ length: 24 }, (_, i) => {
-      if (i === 0) return '12a';
-      if (i < 12) return `${i}a`;
-      if (i === 12) return '12p';
-      return `${i - 12}p`;
-    });
-    
-    let chartData: [number, number, number, number][] = [];
-    let maxGames = 30;
-    
-    if (heatmapData && heatmapData.data && Array.isArray(heatmapData.data)) {
-      chartData = heatmapData.data.map((item: HeatmapDataPoint) => [
-        item.hour,
-        item.day,
-        item.win_rate,
-        item.game_count
-      ]);
-      
-      maxGames = Math.max(...heatmapData.data.map((item: HeatmapDataPoint) => item.game_count), 1);
-    }
-
-    chart.setOption({
-      backgroundColor: 'transparent',
-      tooltip: {
-        position: 'top',
-        backgroundColor: '#3c3836',
-        borderColor: '#504945',
-        textStyle: { color: '#ebdbb2', fontSize: 11 },
-        formatter: (params: any) => {
-          const winRate = params.value[2];
-          const games = params.value[3];
-          if (games === 0) {
-            return `${days[params.value[1]]} ${hours[params.value[0]]}<br/>No games played`;
-          }
-          return `${days[params.value[1]]} ${hours[params.value[0]]}<br/>Win Rate: ${winRate}%<br/>Games: ${games}`;
-        }
-      },
-      grid: { left: '8%', right: '2%', top: '3%', bottom: '15%', containLabel: true },
-      xAxis: {
-        type: 'category',
-        data: hours,
-        splitArea: { show: false },
-        axisLine: { show: false },
-        axisTick: { show: false },
-        axisLabel: { 
-          color: '#a89984', 
-          fontSize: 9,
-          interval: 2, // Show every 3rd hour
-          rotate: 0
-        }
-      },
-      yAxis: {
-        type: 'category',
-        data: days,
-        splitArea: { show: false },
-        axisLine: { show: false },
-        axisTick: { show: false },
-        axisLabel: { color: '#a89984', fontSize: 10 },
-        inverse: true // Display from top to bottom (Sunday at top, Saturday at bottom)
-      },
-      visualMap: {
-        show: false, // Hide the visual map since we're using custom colors
-        min: 0,
-        max: 100
-      },
-      series: [{
-        type: 'heatmap',
-        data: chartData.map(item => {
-          const [hour, day, winRate, gameCount] = item;
-          
-          // Special handling for cells with no games
-          if (gameCount === 0) {
-            // Use neutral yellow color with very low opacity
-            return {
-              value: [hour, day, 50, 0], // Show as 50% win rate
-              itemStyle: {
-                color: 'rgba(250, 189, 47, 0.05)' // Yellow with 5% opacity
-              }
-            };
-          }
-          
-          // Calculate brightness based on game count (0.3 to 1.0)
-          // More games = brighter, fewer games = darker
-          const brightness = Math.max(0.3, Math.min(1.0, gameCount / maxGames));
-          
-          // Determine color based on win rate
-          let baseColor;
-          if (winRate < 35) {
-            baseColor = [251, 73, 52]; // Red (#fb4934)
-          } else if (winRate < 45) {
-            baseColor = [254, 128, 25]; // Orange (#fe8019)
-          } else if (winRate < 55) {
-            baseColor = [250, 189, 47]; // Yellow (#fabd2f)
-          } else if (winRate < 65) {
-            baseColor = [184, 187, 38]; // Light green (#b8bb26)
-          } else {
-            baseColor = [152, 151, 26]; // Dark green (#98971a)
-          }
-          
-          // Apply brightness to the color
-          const adjustedColor = baseColor.map(c => Math.round(c * brightness));
-          const colorString = `rgb(${adjustedColor[0]}, ${adjustedColor[1]}, ${adjustedColor[2]})`;
-          
-          return {
-            value: [hour, day, winRate, gameCount],
-            itemStyle: {
-              color: colorString
-            }
-          };
-        }),
-        label: { show: false },
-        itemStyle: {
-          borderColor: '#282828',
-          borderWidth: 1
-        },
-        emphasis: {
-          itemStyle: {
-            shadowBlur: 10,
-            shadowColor: 'rgba(0, 0, 0, 0.5)',
-            borderColor: '#fbf1c7',
-            borderWidth: 2
-          }
-        }
-      }]
-    });
-
-    const resizeObserver = new ResizeObserver(() => chart.resize());
-    resizeObserver.observe(performanceHeatmapRef.current);
-
-    return () => {
-      resizeObserver.disconnect();
-      chart.dispose();
-    };
-  }, [data, heatmapData]);
+  const heatmapCells: DitherHeatmapCell[] = Array.isArray(heatmapData?.data)
+    ? heatmapData.data.map(point => ({
+        day: point.day,
+        hour: point.hour,
+        winRate: point.game_count === 0 ? null : point.win_rate,
+        games: point.game_count,
+      }))
+    : [];
 
   const generatePNG = async () => {
     if (!tearsheetRef.current) return;
@@ -843,8 +635,7 @@ function PlayerTearsheet() {
           }}>
             📈 Win Rate Trend
           </h3>
-          <div 
-            ref={winRateTimelineRef}
+          <div
             style={{
               width: '100%',
               height: '280px',
@@ -853,7 +644,22 @@ function PlayerTearsheet() {
               border: '1px solid #3c3836',
               padding: '1rem'
             }}
-          />
+          >
+            <LineChart
+              data={timelineRows}
+              config={{ winRate: { label: '20-Game Win Rate', color: playerChartColor } }}
+            >
+              <XAxis dataKey="game" />
+              <YAxis tickFormatter={(value) => `${value}%`} />
+              <Tooltip
+                labelKey="label"
+                valueFormatter={(value) => `${value.toFixed(1)}%`}
+              />
+              <Line dataKey="winRate" variant="gradient">
+                <ActiveDot variant="colored-border" />
+              </Line>
+            </LineChart>
+          </div>
         </div>
 
         {/* Performance Heatmap */}
@@ -866,8 +672,7 @@ function PlayerTearsheet() {
           }}>
             🔥 Performance Heatmap
           </h3>
-          <div 
-            ref={performanceHeatmapRef}
+          <div
             style={{
               width: '100%',
               height: '320px',
@@ -876,7 +681,9 @@ function PlayerTearsheet() {
               border: '1px solid #3c3836',
               padding: '1rem'
             }}
-          />
+          >
+            <DitherHeatmap cells={heatmapCells} height={280} metricLabel="win rate" />
+          </div>
         </div>
 
         {/* Top Characters */}

--- a/frontend/src/SessionDetail.tsx
+++ b/frontend/src/SessionDetail.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import * as echarts from 'echarts';
+import { PieChart, Pie } from './components/dither';
 import CharacterDisplay from './components/CharacterDisplay';
 import MatchEditorModal, { type EditableMatch } from './components/MatchEditorModal';
 import { LoadingState, ErrorState } from './components/Feedback';
@@ -26,6 +26,11 @@ interface SessionStats {
   }>;
 }
 
+interface WinSplitRow {
+  player: string;
+  wins: number;
+}
+
 interface SessionMatchesResponse {
   success: boolean;
   matches: EditableMatch[];
@@ -42,7 +47,6 @@ function SessionDetail() {
   const [matchesLoading, setMatchesLoading] = useState(true);
   const [matchesError, setMatchesError] = useState<string | null>(null);
   const [editingMatch, setEditingMatch] = useState<EditableMatch | null>(null);
-  const chartRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (session_id) {
@@ -95,46 +99,13 @@ function SessionDetail() {
     fetchSessionStats();
   };
 
-  // Mini donut chart
-  useEffect(() => {
-    if (!chartRef.current || !stats) return;
-
-    const chartInstance = echarts.init(chartRef.current);
-
-    const option = {
-      backgroundColor: 'transparent',
-      series: [{
-        type: 'pie',
-        radius: ['60%', '85%'],
-        center: ['50%', '50%'],
-        avoidLabelOverlap: false,
-        label: { show: false },
-        labelLine: { show: false },
-        data: [
-          { value: stats.shayne_wins, name: 'Shayne', itemStyle: { color: '#fe8019' } },
-          { value: stats.matt_wins, name: 'Matt', itemStyle: { color: '#b8bb26' } }
-        ],
-        emphasis: {
-          scale: false,
-          itemStyle: {
-            shadowBlur: 10,
-            shadowOffsetX: 0,
-            shadowColor: 'rgba(0, 0, 0, 0.5)'
-          }
-        }
-      }]
-    };
-
-    chartInstance.setOption(option);
-
-    const handleResize = () => chartInstance.resize();
-    window.addEventListener('resize', handleResize);
-
-    return () => {
-      window.removeEventListener('resize', handleResize);
-      chartInstance.dispose();
-    };
-  }, [stats]);
+  // Mini donut chart rows (Shayne vs Matt win split)
+  const winSplitData: WinSplitRow[] = stats
+    ? [
+        { player: 'Shayne', wins: stats.shayne_wins },
+        { player: 'Matt', wins: stats.matt_wins },
+      ]
+    : [];
 
   const formatDateTime = (dateStr: string) => {
     const date = new Date(dateStr);
@@ -281,7 +252,20 @@ function SessionDetail() {
               {stats.total_games} games played
             </div>
           </div>
-          <div ref={chartRef} style={{ width: 120, height: 120 }} />
+          <div style={{ width: 120, height: 120 }}>
+            <PieChart
+              data={winSplitData}
+              config={{
+                Shayne: { label: 'Shayne', color: 'orange' },
+                Matt: { label: 'Matt', color: 'green' },
+              }}
+              dataKey="wins"
+              nameKey="player"
+              innerRadius={0.7}
+            >
+              <Pie variant="gradient" />
+            </PieChart>
+          </div>
         </div>
       </div>
 

--- a/frontend/src/SessionHistory.tsx
+++ b/frontend/src/SessionHistory.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import * as echarts from 'echarts';
+import { BarChart, Bar, XAxis, YAxis, Legend, Tooltip } from './components/dither';
 
 interface Session {
   session_id: string;
@@ -22,13 +22,18 @@ interface TimelineData {
   duration_minutes: number;
 }
 
+interface ActivityChartRow {
+  date: string;
+  shayne_wins: number;
+  matt_wins: number;
+}
+
 function SessionHistory() {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filterMinGames, setFilterMinGames] = useState(0);
   const [timelineData, setTimelineData] = useState<TimelineData[]>([]);
-  const timelineChartRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     fetchSessions();
@@ -102,155 +107,12 @@ function SessionHistory() {
     ? Math.round(sessions.reduce((sum, s) => sum + s.duration_minutes, 0) / sessions.length)
     : 0;
 
-  // Timeline Chart
-  useEffect(() => {
-    if (!timelineData || timelineData.length === 0) return;
-    if (!timelineChartRef.current) return;
-
-    const chart = echarts.init(timelineChartRef.current);
-
-    // Format dates for display
-    const dates = timelineData.map(d => {
-      const date = new Date(d.datetime);
-      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-    });
-    const games = timelineData.map(d => d.games);
-
-    // Calculate rolling average (window of 5 sessions)
-    const rollingAvg: number[] = [];
-    const window = Math.min(5, Math.ceil(timelineData.length / 10)); // Adaptive window
-    for (let i = 0; i < games.length; i++) {
-      const start = Math.max(0, i - Math.floor(window / 2));
-      const end = Math.min(games.length, i + Math.ceil(window / 2));
-      const slice = games.slice(start, end);
-      const avg = slice.reduce((sum, val) => sum + val, 0) / slice.length;
-      rollingAvg.push(parseFloat(avg.toFixed(1)));
-    }
-
-    chart.setOption({
-      backgroundColor: 'transparent',
-      tooltip: {
-        trigger: 'axis',
-        axisPointer: { type: 'cross' },
-        backgroundColor: '#3c3836',
-        borderColor: '#504945',
-        borderWidth: 2,
-        textStyle: { color: '#ebdbb2', fontSize: 11 },
-        formatter: (params: any) => {
-          const dataIndex = params[0].dataIndex;
-          const session = timelineData[dataIndex];
-          const date = new Date(session.datetime);
-          const formattedDate = date.toLocaleDateString('en-US', { 
-            month: 'short', 
-            day: 'numeric',
-            year: 'numeric'
-          });
-          const shayneWR = session.games > 0 ? ((session.shayne_wins / session.games) * 100).toFixed(1) : '0';
-          const mattWR = session.games > 0 ? ((session.matt_wins / session.games) * 100).toFixed(1) : '0';
-          
-          let tooltip = `<div style="font-weight: bold; margin-bottom: 4px;">${formattedDate}</div>`;
-          
-          params.forEach((param: any) => {
-            if (param.seriesName === 'Games') {
-              tooltip += `<div style="color: #83a598;">Games: ${param.value}</div>`;
-            } else if (param.seriesName === 'Trend') {
-              tooltip += `<div style="color: #fabd2f;">Avg: ${param.value}</div>`;
-            }
-          });
-          
-          tooltip += `<div style="color: #fe8019;">Shayne: ${session.shayne_wins}W (${shayneWR}%)</div>` +
-                     `<div style="color: #b8bb26;">Matt: ${session.matt_wins}W (${mattWR}%)</div>` +
-                     `<div style="color: #a89984; font-size: 10px;">Duration: ${session.duration_minutes}min</div>`;
-          
-          return tooltip;
-        }
-      },
-      legend: {
-        data: ['Games', 'Trend'],
-        textStyle: { color: '#a89984', fontSize: 11 },
-        top: 0,
-        right: '8%'
-      },
-      grid: { 
-        left: '8%', 
-        right: '8%', 
-        top: '15%', 
-        bottom: timelineData.length > 20 ? '20%' : '15%',
-        containLabel: true 
-      },
-      xAxis: {
-        type: 'category',
-        data: dates,
-        axisLine: { lineStyle: { color: '#504945', width: 2 } },
-        axisLabel: { 
-          color: '#a89984', 
-          fontSize: 9,
-          rotate: timelineData.length > 20 ? 45 : 0,
-          interval: timelineData.length > 30 ? Math.floor(timelineData.length / 20) : 0
-        },
-        axisTick: { lineStyle: { color: '#504945' } }
-      },
-      yAxis: {
-        type: 'value',
-        axisLine: { show: true, lineStyle: { color: '#504945', width: 2 } },
-        axisLabel: { color: '#a89984', fontSize: 10 },
-        splitLine: { lineStyle: { color: '#3c3836', type: 'dashed' } }
-      },
-      series: [
-        {
-          name: 'Games',
-          data: games,
-          type: 'bar',
-          itemStyle: {
-            color: '#83a598',
-            borderRadius: [4, 4, 0, 0]
-          },
-          emphasis: {
-            itemStyle: {
-              color: '#a3c0b8'
-            }
-          },
-          barWidth: '60%',
-          animationDelay: (idx: number) => idx * 20
-        },
-        {
-          name: 'Trend',
-          data: rollingAvg,
-          type: 'line',
-          smooth: true,
-          symbol: 'circle',
-          symbolSize: 6,
-          lineStyle: {
-            color: '#fabd2f',
-            width: 3
-          },
-          itemStyle: {
-            color: '#fabd2f',
-            borderColor: '#d79921',
-            borderWidth: 2
-          },
-          emphasis: {
-            itemStyle: {
-              color: '#fabd2f',
-              borderColor: '#d79921',
-              borderWidth: 3,
-              shadowBlur: 10,
-              shadowColor: 'rgba(250, 189, 47, 0.5)'
-            }
-          },
-          z: 10
-        }
-      ]
-    });
-
-    const resizeObserver = new ResizeObserver(() => chart.resize());
-    resizeObserver.observe(timelineChartRef.current);
-
-    return () => {
-      resizeObserver.disconnect();
-      chart.dispose();
-    };
-  }, [timelineData]);
+  // Timeline chart rows: one bar pair per session, stacked so total height = games played
+  const activityChartData: ActivityChartRow[] = timelineData.map((d) => ({
+    date: new Date(d.datetime).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+    shayne_wins: d.shayne_wins,
+    matt_wins: d.matt_wins,
+  }));
 
   if (loading) {
     return (
@@ -418,7 +280,23 @@ function SessionHistory() {
           }}>
             Games played across {timelineData.length} session{timelineData.length !== 1 ? 's' : ''}
           </div>
-          <div ref={timelineChartRef} style={{ height: '300px', width: '100%' }}></div>
+          <div style={{ height: '300px', width: '100%' }}>
+            <BarChart
+              data={activityChartData}
+              config={{
+                shayne_wins: { label: 'Shayne wins', color: 'orange' },
+                matt_wins: { label: 'Matt wins', color: 'green' },
+              }}
+              stackType="stacked"
+            >
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Legend isClickable />
+              <Tooltip labelKey="date" />
+              <Bar dataKey="shayne_wins" variant="hatched" />
+              <Bar dataKey="matt_wins" variant="gradient" />
+            </BarChart>
+          </div>
         </div>
       )}
 

--- a/frontend/src/SessionStats.tsx
+++ b/frontend/src/SessionStats.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, forwardRef, useImperativeHandle, useRef } from 'react';
-import type { ECharts } from 'echarts';
+import { useEffect, useState, forwardRef, useImperativeHandle } from 'react';
+import { PieChart, Pie } from './components/dither';
 import CharacterDisplay from './components/CharacterDisplay';
 import { LoadingState, ErrorState } from './components/Feedback';
 import { stageImages } from './lib/stages';
@@ -89,8 +89,6 @@ const SessionStats = forwardRef<SessionStatsRef, SessionStatsProps>(({ shayneCha
   const [advancedMetrics, setAdvancedMetrics] = useState<AdvancedMetrics | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const chartRef = useRef<HTMLDivElement>(null);
-  const chartInstanceRef = useRef<ECharts | null>(null);
 
   const fetchStats = async () => {
     setLoading(true);
@@ -153,66 +151,6 @@ const SessionStats = forwardRef<SessionStatsRef, SessionStatsProps>(({ shayneCha
   useEffect(() => {
     fetchMatchupStats();
   }, [shayneCharacter, mattCharacter]);
-
-  // Mini donut chart for win distribution
-  // echarts is dynamically imported so it stays out of the eager index chunk
-  // (SessionStats renders on the homepage; all other chart pages are lazy routes).
-  useEffect(() => {
-    if (!chartRef.current || !stats) return;
-
-    let disposed = false;
-    let chartInstance: ECharts | null = null;
-    let handleResize: (() => void) | null = null;
-
-    const option = {
-      backgroundColor: 'transparent',
-      series: [{
-        type: 'pie',
-        radius: ['60%', '85%'],
-        center: ['50%', '50%'],
-        avoidLabelOverlap: false,
-        label: { show: false },
-        labelLine: { show: false },
-        data: [
-          { value: stats.shayne_wins, name: 'Shayne', itemStyle: { color: '#fe8019' } },
-          { value: stats.matt_wins, name: 'Matt', itemStyle: { color: '#b8bb26' } }
-        ],
-        emphasis: {
-          scale: false,
-          itemStyle: {
-            shadowBlur: 10,
-            shadowOffsetX: 0,
-            shadowColor: 'rgba(0, 0, 0, 0.5)'
-          }
-        }
-      }]
-    };
-
-    import('echarts')
-      .then((echarts) => {
-        if (disposed || !chartRef.current) return;
-
-        chartInstance = echarts.init(chartRef.current);
-        chartInstanceRef.current = chartInstance;
-        chartInstance.setOption(option);
-
-        handleResize = () => chartInstance?.resize();
-        window.addEventListener('resize', handleResize);
-      })
-      .catch((err) => {
-        console.error('Failed to load echarts:', err);
-      });
-
-    return () => {
-      disposed = true;
-      if (handleResize) window.removeEventListener('resize', handleResize);
-      if (chartInstance) {
-        chartInstance.dispose();
-        chartInstance = null;
-      }
-      if (chartInstanceRef.current) chartInstanceRef.current = null;
-    };
-  }, [stats]);
 
   const handleShareSession = () => {
     window.open('/session-tearsheet', '_blank', 'width=900,height=1200');
@@ -309,7 +247,23 @@ const SessionStats = forwardRef<SessionStatsRef, SessionStatsProps>(({ shayneCha
                   {stats.total_games} games played
                 </div>
               </div>
-              <div ref={chartRef} style={{ width: 80, height: 80 }} />
+              <div style={{ width: 80, height: 80 }}>
+                <PieChart
+                  data={[
+                    { player: 'Shayne', wins: stats.shayne_wins },
+                    { player: 'Matt', wins: stats.matt_wins },
+                  ]}
+                  config={{
+                    Shayne: { label: 'Shayne', color: 'orange' },
+                    Matt: { label: 'Matt', color: 'green' },
+                  }}
+                  dataKey="wins"
+                  nameKey="player"
+                  innerRadius={0.62}
+                >
+                  <Pie variant="gradient" />
+                </PieChart>
+              </div>
             </div>
           </div>
 

--- a/frontend/src/StatsPage.tsx
+++ b/frontend/src/StatsPage.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
-import * as echarts from 'echarts';
 import CharacterDisplay from './components/CharacterDisplay';
+import { BarChart, Bar, XAxis, YAxis, Tooltip } from './components/dither';
 
 // ===== TYPE DEFINITIONS =====
 interface MonthlyActivityItem {
@@ -139,9 +139,6 @@ const StatsPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [activeTooltip, setActiveTooltip] = useState<string | null>(null);
   
-  const chartRef = useRef<HTMLDivElement>(null);
-  const chartInstanceRef = useRef<echarts.ECharts | null>(null);
-
   useEffect(() => {
     const fetchStats = async () => {
       setLoading(true);
@@ -182,84 +179,13 @@ const StatsPage: React.FC = () => {
   }, []);
 
   // Initialize eCharts chart for monthly activity
-  useEffect(() => {
-    if (!chartRef.current || !stats) return;
-
-    const chartInstance = echarts.init(chartRef.current);
-    chartInstanceRef.current = chartInstance;
-
-    const months = stats.monthly_activity.map(item => {
-      const [year, month] = item.month.split('-');
-      const monthName = new Date(Number(year), Number(month) - 1).toLocaleString('default', { month: 'short' });
-      const yearShort = year.slice(-2);
-      return `${monthName}. '${yearShort}`;
-    });
-    const gamesData = stats.monthly_activity.map(item => item.games);
-
-    const option = {
-      backgroundColor: 'transparent',
-      grid: {
-        left: '8%',
-        right: '8%',
-        top: '10%',
-        bottom: stats.monthly_activity.length > 12 ? '15%' : '10%',
-        containLabel: true
-      },
-      xAxis: {
-        type: 'category',
-        data: months,
-        axisLine: { lineStyle: { color: '#504945' } },
-        axisLabel: {
-          color: '#ebdbb2',
-          fontSize: 11,
-          rotate: stats.monthly_activity.length > 12 ? -45 : 0
-        },
-        axisTick: { lineStyle: { color: '#504945' } }
-      },
-      yAxis: {
-        type: 'value',
-        axisLine: { lineStyle: { color: '#504945' } },
-        axisLabel: { color: '#ebdbb2', fontSize: 11 },
-        splitLine: { lineStyle: { color: '#3c3836' } }
-      },
-      series: [{
-        type: 'bar',
-        data: gamesData,
-        itemStyle: {
-          color: '#83a598',
-          borderRadius: [4, 4, 0, 0]
-        },
-        barWidth: '50%',
-        label: {
-          show: true,
-          position: 'top',
-          color: '#ebdbb2',
-          fontSize: 11,
-          fontWeight: 'bold'
-        }
-      }],
-      tooltip: {
-        trigger: 'axis',
-        backgroundColor: 'rgba(60, 56, 54, 0.95)',
-        borderColor: '#504945',
-        textStyle: { color: '#ebdbb2' },
-        formatter: (params: any) => {
-          const param = params[0];
-          return `${param.name}<br/>Games: ${param.value}`;
-        }
-      }
-    };
-
-    chartInstance.setOption(option);
-
-    const handleResize = () => chartInstance.resize();
-    window.addEventListener('resize', handleResize);
-
-    return () => {
-      window.removeEventListener('resize', handleResize);
-      chartInstance.dispose();
-    };
-  }, [stats]);
+  const monthlyChartData = stats
+    ? stats.monthly_activity.map(item => {
+        const [year, month] = item.month.split('-');
+        const monthName = new Date(Number(year), Number(month) - 1).toLocaleString('default', { month: 'short' });
+        return { month: `${monthName}. '${year.slice(-2)}`, games: item.games };
+      })
+    : [];
 
   if (loading) return <div className="stats-container"><div style={{ textAlign: 'center', padding: '3rem', fontSize: '1.2rem' }}>Loading statistics...</div></div>;
   if (error) return <div className="stats-container"><div className="error" style={{ textAlign: 'center', padding: '2rem' }}>{error}</div></div>;
@@ -843,7 +769,14 @@ const StatsPage: React.FC = () => {
       <section className="stats-section">
         <h2 style={{ fontSize: '1.3rem', marginBottom: '0.75rem', color: '#fbf1c7' }}>Games by Month</h2>
         <div className="card" style={{ padding: '1rem' }}>
-          <div ref={chartRef} style={{ width: '100%', height: 300 }} />
+          <div style={{ width: '100%', height: 300 }}>
+            <BarChart data={monthlyChartData} config={{ games: { label: 'Games', color: 'blue' } }}>
+              <XAxis dataKey="month" />
+              <YAxis />
+              <Tooltip labelKey="month" />
+              <Bar dataKey="games" variant="gradient" />
+            </BarChart>
+          </div>
         </div>
       </section>
 

--- a/frontend/src/components/PerformanceHeatmap.tsx
+++ b/frontend/src/components/PerformanceHeatmap.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef } from 'react';
-import * as echarts from 'echarts';
+import React from 'react';
+import { DitherHeatmap, type DitherHeatmapCell } from './dither';
 
 interface HeatmapProps {
   data: Array<{
@@ -23,6 +23,40 @@ function seededRandom(seed: number) {
   };
 }
 
+// Simulated fallback: realistic gaming patterns (higher activity in evenings)
+function buildSimulatedCells(seed: number): DitherHeatmapCell[] {
+  const random = seededRandom(seed);
+  const cells: DitherHeatmapCell[] = [];
+
+  for (let d = 0; d < 7; d++) {
+    for (let h = 0; h < 24; h++) {
+      let baseValue = random() * 40;
+      let gameCount = Math.floor(random() * 5);
+
+      if (h >= 18 && h <= 23) {
+        baseValue += 40; // Evening boost
+        gameCount += Math.floor(random() * 20) + 5;
+      } else if (h >= 12 && h < 18) {
+        baseValue += 20; // Afternoon boost
+        gameCount += Math.floor(random() * 10) + 2;
+      } else if (h >= 0 && h < 6) {
+        baseValue -= 20; // Late night penalty
+        gameCount = Math.floor(random() * 3);
+      }
+
+      const winRate = Math.max(0, Math.min(100, baseValue + random() * 30));
+      cells.push({
+        day: d,
+        hour: h,
+        winRate: gameCount === 0 ? null : Math.round(winRate),
+        games: gameCount
+      });
+    }
+  }
+
+  return cells;
+}
+
 export const PerformanceHeatmap: React.FC<HeatmapProps> = ({
   data,
   usingSimulatedData,
@@ -30,178 +64,19 @@ export const PerformanceHeatmap: React.FC<HeatmapProps> = ({
   character,
   height = '260px'
 }) => {
-  const heatmapRef = useRef<HTMLDivElement>(null);
+  const cells: DitherHeatmapCell[] =
+    data && !usingSimulatedData
+      ? data.map(item => ({
+          day: item.day,
+          hour: item.hour,
+          winRate: item.game_count === 0 ? null : item.win_rate,
+          games: item.game_count
+        }))
+      : buildSimulatedCells(
+          (username?.charCodeAt(0) || 0) * 1000 + (character?.charCodeAt(0) || 0)
+        );
 
-  useEffect(() => {
-    if (!heatmapRef.current) return;
+  const heightPx = Number.parseInt(height, 10) || 260;
 
-    const chart = echarts.init(heatmapRef.current);
-    
-    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-    const hours = Array.from({ length: 24 }, (_, i) => {
-      if (i === 0) return '12a';
-      if (i < 12) return `${i}a`;
-      if (i === 12) return '12p';
-      return `${i - 12}p`;
-    });
-    
-    // Format: [hour, day, winRate, gameCount]
-    let chartData: [number, number, number, number][] = [];
-    let maxGames = 30;
-    
-    if (data && !usingSimulatedData) {
-      // Use real data from backend
-      chartData = data.map((item: any) => [
-        item.hour,
-        item.day,
-        item.win_rate,
-        item.game_count
-      ]);
-      
-      // Calculate actual max games for normalization
-      maxGames = Math.max(...data.map((item: any) => item.game_count), 1);
-    } else {
-      // Use seeded random data for consistent display
-      const seed = (username?.charCodeAt(0) || 0) * 1000 + (character?.charCodeAt(0) || 0);
-      const random = seededRandom(seed);
-      
-      for (let d = 0; d < 7; d++) {
-        for (let h = 0; h < 24; h++) {
-          // Simulate realistic gaming patterns (higher activity in evenings)
-          let baseValue = random() * 40;
-          let gameCount = Math.floor(random() * 5); // Base game count
-          
-          if (h >= 18 && h <= 23) {
-            baseValue += 40; // Evening boost
-            gameCount += Math.floor(random() * 20) + 5; // More games in evening
-          } else if (h >= 12 && h < 18) {
-            baseValue += 20; // Afternoon boost
-            gameCount += Math.floor(random() * 10) + 2; // Some games in afternoon
-          } else if (h >= 0 && h < 6) {
-            baseValue -= 20; // Late night penalty
-            gameCount = Math.floor(random() * 3); // Very few games late night
-          }
-          
-          const winRate = Math.max(0, Math.min(100, baseValue + (random() * 30)));
-          chartData.push([h, d, Math.round(winRate), gameCount]);
-        }
-      }
-    }
-
-    chart.setOption({
-      backgroundColor: 'transparent',
-      tooltip: {
-        position: 'top',
-        backgroundColor: '#3c3836',
-        borderColor: '#504945',
-        textStyle: { color: '#ebdbb2', fontSize: 11 },
-        formatter: (params: any) => {
-          const winRate = params.value[2];
-          const games = params.value[3];
-          if (games === 0) {
-            return `${days[params.value[1]]} ${hours[params.value[0]]}<br/>No games played`;
-          }
-          return `${days[params.value[1]]} ${hours[params.value[0]]}<br/>Win Rate: ${winRate}%<br/>Games: ${games}`;
-        }
-      },
-      grid: { left: '8%', right: '2%', top: '3%', bottom: '15%', containLabel: true },
-      xAxis: {
-        type: 'category',
-        data: hours,
-        splitArea: { show: false },
-        axisLine: { show: false },
-        axisTick: { show: false },
-        axisLabel: { 
-          color: '#a89984', 
-          fontSize: 9,
-          interval: 2, // Show every 3rd hour
-          rotate: 0
-        }
-      },
-      yAxis: {
-        type: 'category',
-        data: days,
-        splitArea: { show: false },
-        axisLine: { show: false },
-        axisTick: { show: false },
-        axisLabel: { color: '#a89984', fontSize: 10 },
-        inverse: true // Display from top to bottom (Sunday at top, Saturday at bottom)
-      },
-      visualMap: {
-        show: false, // Hide the visual map since we're using custom colors
-        min: 0,
-        max: 100
-      },
-      series: [{
-        type: 'heatmap',
-        data: chartData.map(item => {
-          const [hour, day, winRate, gameCount] = item;
-          
-          // Special handling for cells with no games
-          if (gameCount === 0) {
-            // Use neutral yellow color with very low opacity
-            return {
-              value: [hour, day, 50, 0], // Show as 50% win rate
-              itemStyle: {
-                color: 'rgba(250, 189, 47, 0.05)' // Yellow with 5% opacity
-              }
-            };
-          }
-          
-          // Calculate brightness based on game count (0.3 to 1.0)
-          // More games = brighter, fewer games = darker
-          const brightness = Math.max(0.3, Math.min(1.0, gameCount / maxGames));
-          
-          // Determine color based on win rate
-          let baseColor;
-          if (winRate < 35) {
-            baseColor = [251, 73, 52]; // Red (#fb4934)
-          } else if (winRate < 45) {
-            baseColor = [254, 128, 25]; // Orange (#fe8019)
-          } else if (winRate < 55) {
-            baseColor = [250, 189, 47]; // Yellow (#fabd2f)
-          } else if (winRate < 65) {
-            baseColor = [184, 187, 38]; // Light green (#b8bb26)
-          } else {
-            baseColor = [152, 151, 26]; // Dark green (#98971a)
-          }
-          
-          // Apply brightness to the color
-          const adjustedColor = baseColor.map(c => Math.round(c * brightness));
-          const colorString = `rgb(${adjustedColor[0]}, ${adjustedColor[1]}, ${adjustedColor[2]})`;
-          
-          return {
-            value: [hour, day, winRate, gameCount],
-            itemStyle: {
-              color: colorString
-            }
-          };
-        }),
-        label: { show: false },
-        itemStyle: {
-          borderColor: '#282828',
-          borderWidth: 1
-        },
-        emphasis: {
-          itemStyle: {
-            shadowBlur: 10,
-            shadowColor: 'rgba(0, 0, 0, 0.5)',
-            borderColor: '#fbf1c7',
-            borderWidth: 2
-          }
-        }
-      }]
-    });
-
-    const resizeObserver = new ResizeObserver(() => chart.resize());
-    resizeObserver.observe(heatmapRef.current);
-
-    return () => {
-      resizeObserver.disconnect();
-      chart.dispose();
-    };
-  }, [data, usingSimulatedData, username, character, height]);
-
-  return <div ref={heatmapRef} style={{ height, width: '100%' }}></div>;
+  return <DitherHeatmap cells={cells} height={heightPx} metricLabel="win rate" />;
 };
-

--- a/frontend/src/components/dither/area-chart.tsx
+++ b/frontend/src/components/dither/area-chart.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { CartesianCanvas } from "./cartesian-canvas"
+import { type CartesianChartProps, CartesianRoot } from "./cartesian-root"
+
+// `object` rather than `Record<string, unknown>`: interfaces don't get an
+// implicit index signature, so interface-typed rows failed to satisfy the
+// generic. Internal layers still index rows through their own Row type.
+type Row = object
+
+/** Composable dither **area** chart. Compose `<Area>`, `<Grid>`, axes, … inside. */
+export function AreaChart<TData extends Row>(
+  props: CartesianChartProps<TData>
+) {
+  return <CartesianRoot chartType="area" Canvas={CartesianCanvas} {...props} />
+}
+
+/** Composable dither **line** chart — `<Line>` series with a glow under the line. */
+export function LineChart<TData extends Row>(
+  props: CartesianChartProps<TData>
+) {
+  return <CartesianRoot chartType="line" Canvas={CartesianCanvas} {...props} />
+}
+
+export type AreaChartProps<TData extends Row> = CartesianChartProps<TData>

--- a/frontend/src/components/dither/area.tsx
+++ b/frontend/src/components/dither/area.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import { type ReactNode, useEffect } from "react"
+import {
+  type AreaVariant,
+  type SeriesKind,
+  type StrokeVariant,
+  useChartPart,
+} from "./chart-context"
+import { SeriesContext } from "./series-context"
+
+export type SeriesProps = {
+  dataKey: string
+  variant?: AreaVariant
+  strokeVariant?: StrokeVariant
+  isClickable?: boolean
+  children?: ReactNode
+}
+
+/**
+ * Shared implementation for the continuous series (`<Area>`, `<Line>`). The
+ * dithered fill/line is painted on the canvas; this registers the series so the
+ * canvas knows how to draw it, wires click-to-select via a transparent band
+ * polygon, and exposes the series to child `<Dot>`/`<ActiveDot>` markers.
+ */
+function CartesianSeries({
+  part,
+  kind,
+  dataKey,
+  variant = "gradient",
+  strokeVariant = "solid",
+  isClickable = false,
+  children,
+}: SeriesProps & { part: string; kind: SeriesKind }) {
+  const ctx = useChartPart(part, kind === "line" ? "line" : "area")
+  const { registerSeries, unregisterSeries } = ctx
+
+  if (import.meta.env.DEV && !ctx.config[dataKey]) {
+    console.warn(
+      `<${part} dataKey="${dataKey}" />: "${dataKey}" is not in the chart \`config\`. Add it so the series has a colour and label.`
+    )
+  }
+
+  useEffect(() => {
+    registerSeries({ dataKey, kind, variant, strokeVariant })
+    return () => unregisterSeries(dataKey)
+  }, [dataKey, kind, variant, strokeVariant, registerSeries, unregisterSeries])
+
+  const band = ctx.bands[dataKey]
+  if (!ctx.ready || !band) return null
+
+  const seed = ctx.seedOf(dataKey)
+  const emphasis = ctx.selectedDataKey ?? ctx.focusDataKey
+  const dimmed = emphasis !== null && emphasis !== dataKey
+  const onClick = isClickable
+    ? () => ctx.selectDataKey(ctx.selectedDataKey === dataKey ? null : dataKey)
+    : undefined
+
+  // Transparent hit polygon tracing the series' own band, so clicking a series
+  // selects *that* series. The Legend offers the same toggle accessibly.
+  // One pass out along the top edge, one pass back along the floor.
+  let hitPath: string | null = null
+  if (isClickable) {
+    const parts: string[] = []
+    band.forEach((b, i) => {
+      parts.push(`${i === 0 ? "M" : "L"}${ctx.xCenter(i)},${ctx.y(b[1])}`)
+    })
+    for (let i = band.length - 1; i >= 0; i -= 1) {
+      parts.push(`L${ctx.xCenter(i)},${ctx.y(band[i][0])}`)
+    }
+    hitPath = `${parts.join(" ")} Z`
+  }
+
+  return (
+    <>
+      {hitPath && (
+        // biome-ignore lint/a11y/noStaticElementInteractions: progressive enhancement; the Legend offers the same toggle accessibly
+        <path
+          d={hitPath}
+          fill="transparent"
+          style={{ cursor: "pointer" }}
+          onClick={onClick}
+        />
+      )}
+      <SeriesContext value={{ dataKey, seed, dimmed }}>
+        {children}
+      </SeriesContext>
+    </>
+  )
+}
+
+export type AreaProps = SeriesProps
+
+/** One area series — dithered fill from the value line down to its floor. */
+export function Area(props: AreaProps) {
+  return <CartesianSeries part="Area" kind="area" {...props} />
+}
+
+/** One line series — bright line with a thin dither glow hugging it. */
+export function Line(props: AreaProps) {
+  return <CartesianSeries part="Line" kind="line" {...props} />
+}

--- a/frontend/src/components/dither/bar-canvas.tsx
+++ b/frontend/src/components/dither/bar-canvas.tsx
@@ -1,0 +1,222 @@
+"use client"
+
+import { useEffect, useMemo, useRef } from "react"
+import { useChart } from "./chart-context"
+import {
+  backingSize,
+  bloomLayerStyle,
+  clamp01,
+  easeOutCubic,
+  paintColumn,
+  prefersReducedMotion,
+} from "./dither-paint"
+
+type Bars = { top: number[]; base: number[] } // per data index, in backing rows
+
+// Fraction of the timeline spent staggering bar starts — the rest is each bar's
+// own grow window, so the rise sweeps across the chart as a wave.
+const STAGGER = 0.55
+
+/**
+ * Dither canvas for bar charts. Each category owns a band; grouped series split
+ * it into side-by-side bars, stacked series share its full width and pile in y.
+ * Every bar is filled with the shared {@link paintColumn} ordered dither. Bars
+ * grow up from their base in a staggered left-to-right wave (eased), and the
+ * hovered category lifts while the rest dim.
+ */
+export function BarCanvas() {
+  const ctx = useChart()
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const bloomRef = useRef<HTMLCanvasElement>(null)
+
+  const { width, height } = ctx.plot
+  const { cols, rows } = backingSize(width, height)
+  const { ready, configKeys, bands, y } = ctx
+
+  // Memoized: per-series bar tops/bases (backing rows) over the data indices.
+  // The canvas re-renders on every hover/cursor tick, so pin this map to the
+  // exact ctx fields it reads plus the backing geometry — a bar hover must not
+  // rebuild every band's geometry.
+  const targets = useMemo(() => {
+    const out: Record<string, Bars> = {}
+    if (!ready) return out
+    const h = height || 1
+    for (const key of configKeys) {
+      const band = bands[key]
+      if (!band) continue
+      out[key] = {
+        top: band.map((b) => (y(b[1]) / h) * (rows - 1)),
+        base: band.map((b) => (y(b[0]) / h) * (rows - 1)),
+      }
+    }
+    return out
+  }, [ready, configKeys, bands, y, height, rows])
+
+  // The RAF loop reads these through refs so it always sees the latest values;
+  // refs are written in an effect (never during render) — mutating a ref
+  // mid-render tears under Strict Mode / concurrent rendering.
+  const state = useRef(ctx)
+  const targetsRef = useRef(targets)
+  useEffect(() => {
+    state.current = ctx
+    targetsRef.current = targets
+  })
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    const c = canvas?.getContext("2d")
+    if (!(canvas && c) || cols <= 0 || rows <= 0) return
+    canvas.width = cols
+    canvas.height = rows
+
+    const bloomCanvas = bloomRef.current
+    const bloomCtx = bloomCanvas?.getContext("2d") ?? null
+    if (bloomCanvas) {
+      bloomCanvas.width = cols
+      bloomCanvas.height = rows
+    }
+
+    const reduce = prefersReducedMotion()
+    const animate = state.current.animate && !reduce
+    const duration = state.current.animationDuration
+    const fx = cols / Math.max(width, 1)
+
+    // Eased grow factor for bar `i` at global progress `prog`.
+    const barProgress = (i: number, len: number, prog: number) => {
+      if (!animate) return 1
+      const start = len > 1 ? (i / (len - 1)) * STAGGER : 0
+      return easeOutCubic(clamp01((prog - start) / (1 - STAGGER)))
+    }
+
+    const paint = (prog: number) => {
+      const s = state.current
+      c.clearRect(0, 0, cols, rows)
+      const stacked = s.stackType === "stacked" || s.stackType === "percent"
+      const keys = s.configKeys
+      keys.forEach((key, si) => {
+        const t = targetsRef.current[key]
+        if (!t) return
+        const seed = s.seedOf(key)
+        const variant = s.seriesSpecs[key]?.variant ?? "gradient"
+        const emphasis = s.selectedDataKey ?? s.focusDataKey
+        const selDim = emphasis !== null && emphasis !== key ? 0.3 : 1
+        for (let i = 0; i < s.dataLength; i++) {
+          const bp = barProgress(i, s.dataLength, prog)
+          const base = t.base[i] ?? rows - 1
+          const top = base + ((t.top[i] ?? base) - base) * bp
+          const active = s.hoverIndex === i
+          const hoverDim =
+            s.hoverIndex != null && !active && s.isMouseInChart ? 0.5 : 1
+          const slot = s.barSlot(i, si, keys.length)
+          const c0 = Math.round(slot.x * fx)
+          const c1 = Math.round((slot.x + slot.width) * fx)
+          for (let x = c0; x < c1; x++) {
+            paintColumn(c, x, top, base, seed, {
+              variant,
+              intensity: intensity + (active ? 0.4 : 0),
+              dim: selDim * hoverDim,
+              stacked,
+            })
+          }
+        }
+      })
+    }
+
+    let raf = 0
+    let animStart = 0
+    let lastProg = -1
+    let lastRevision = state.current.revision
+    let intensity = 0
+    let needsFill = true
+    let lastPaintSig = ""
+    let lastSelected: string | null | undefined = Symbol() as never
+    let lastHover: number | null | undefined = Symbol() as never
+
+    const draw = (now: number) => {
+      raf = requestAnimationFrame(draw)
+      const s = state.current
+      if (!s.ready) return
+      if (bloomCtx) {
+        const on =
+          s.bloom !== "off" &&
+          (!s.bloomOnHover || s.isMouseInChart || s.hovered)
+        if (on) {
+          bloomCtx.clearRect(0, 0, cols, rows)
+          bloomCtx.drawImage(canvas, 0, 0)
+        }
+      }
+      if (s.revision !== lastRevision) {
+        lastRevision = s.revision
+        animStart = 0 // re-play the wave on data change / replay
+        lastProg = -1
+      }
+      if (!animStart) animStart = now
+      const prog = animate ? Math.min(1, (now - animStart) / duration) : 1
+
+      if (prog !== lastProg) {
+        lastProg = prog
+        needsFill = true
+      }
+      const emphasisNow = s.selectedDataKey ?? s.focusDataKey
+      if (emphasisNow !== lastSelected) {
+        lastSelected = emphasisNow
+        needsFill = true
+      }
+      if (s.hoverIndex !== lastHover) {
+        lastHover = s.hoverIndex
+        needsFill = true
+      }
+      const itTarget = s.isMouseInChart || s.hovered ? 1 : 0
+      if (Math.abs(intensity - itTarget) > 0.001) {
+        intensity += (itTarget - intensity) * (reduce ? 1 : 0.16)
+        needsFill = true
+      } else intensity = itTarget
+
+      // Live tweak repaint (variant, stacking) without replaying the wave.
+      const paintSig = `${s.stackType}|${s.configKeys
+        .map((k) => s.seriesSpecs[k]?.variant ?? "")
+        .join(",")}`
+      if (paintSig !== lastPaintSig) {
+        lastPaintSig = paintSig
+        needsFill = true
+      }
+
+      if (!needsFill) return
+      paint(prog)
+      needsFill = false
+    }
+
+    raf = requestAnimationFrame(draw)
+    return () => cancelAnimationFrame(raf)
+  }, [cols, rows, width])
+
+  const bloomActive = ctx.bloomOnHover
+    ? ctx.isMouseInChart || ctx.hovered
+    : true
+  const bloom = bloomLayerStyle(ctx.bloom, bloomActive)
+  const pos = {
+    left: ctx.margins.left,
+    top: ctx.margins.top,
+    width,
+    height,
+  } as const
+
+  return (
+    <>
+      <canvas
+        ref={canvasRef}
+        className="pointer-events-none absolute"
+        style={{ ...pos, imageRendering: "pixelated" }}
+      />
+      <canvas
+        ref={bloomRef}
+        className="pointer-events-none absolute"
+        style={{
+          ...pos,
+          transition: "opacity 220ms ease",
+          ...(bloom ?? { opacity: 0 }),
+        }}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/dither/bar-chart.tsx
+++ b/frontend/src/components/dither/bar-chart.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import { BarCanvas } from "./bar-canvas"
+import { type CartesianChartProps, CartesianRoot } from "./cartesian-root"
+
+// `object` rather than `Record<string, unknown>`: interfaces don't get an
+// implicit index signature, so interface-typed rows failed to satisfy the
+// generic. Internal layers still index rows through their own Row type.
+type Row = object
+
+/** Composable dither **bar** chart — `<Bar>` series, grouped or stacked. */
+export function BarChart<TData extends Row>(props: CartesianChartProps<TData>) {
+  return <CartesianRoot chartType="bar" Canvas={BarCanvas} {...props} />
+}

--- a/frontend/src/components/dither/bar.tsx
+++ b/frontend/src/components/dither/bar.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { type ReactNode, useEffect } from "react"
+import {
+  type AreaVariant,
+  type StrokeVariant,
+  useChartPart,
+} from "./chart-context"
+import { SeriesContext } from "./series-context"
+
+export type BarProps = {
+  dataKey: string
+  variant?: AreaVariant
+  strokeVariant?: StrokeVariant
+  isClickable?: boolean
+  children?: ReactNode
+}
+
+/**
+ * One bar series. The dithered bars are painted on the canvas; this registers
+ * the series and (when `isClickable`) lays transparent hit rects over each bar
+ * — using the shared `barSlot` geometry so clicks line up with the pixels — to
+ * select the series. The Legend offers the same toggle accessibly.
+ */
+export function Bar({
+  dataKey,
+  variant = "gradient",
+  strokeVariant = "solid",
+  isClickable = false,
+  children,
+}: BarProps) {
+  const ctx = useChartPart("Bar", "bar")
+  const { registerSeries, unregisterSeries } = ctx
+
+  if (import.meta.env.DEV && !ctx.config[dataKey]) {
+    console.warn(
+      `<Bar dataKey="${dataKey}" />: "${dataKey}" is not in the chart \`config\`. Add it so the series has a colour and label.`
+    )
+  }
+
+  useEffect(() => {
+    registerSeries({ dataKey, kind: "bar", variant, strokeVariant })
+    return () => unregisterSeries(dataKey)
+  }, [dataKey, variant, strokeVariant, registerSeries, unregisterSeries])
+
+  const band = ctx.bands[dataKey]
+  if (!ctx.ready || !band) return null
+
+  const seed = ctx.seedOf(dataKey)
+  const dimmed = ctx.selectedDataKey !== null && ctx.selectedDataKey !== dataKey
+  const si = ctx.configKeys.indexOf(dataKey)
+  const n = ctx.configKeys.length
+  const onClick = () =>
+    ctx.selectDataKey(ctx.selectedDataKey === dataKey ? null : dataKey)
+
+  return (
+    <>
+      {isClickable &&
+        band.map((b, i) => {
+          const slot = ctx.barSlot(i, si, n)
+          const top = ctx.y(b[1])
+          const base = ctx.y(b[0])
+          return (
+            // biome-ignore lint/a11y/noStaticElementInteractions: progressive enhancement; the Legend offers the same toggle accessibly
+            <rect
+              // biome-ignore lint/suspicious/noArrayIndexKey: index is the stable category position
+              key={i}
+              x={slot.x}
+              y={Math.min(top, base)}
+              width={slot.width}
+              height={Math.abs(base - top)}
+              fill="transparent"
+              style={{ cursor: "pointer" }}
+              onClick={onClick}
+            />
+          )
+        })}
+      <SeriesContext value={{ dataKey, seed, dimmed }}>
+        {children}
+      </SeriesContext>
+    </>
+  )
+}

--- a/frontend/src/components/dither/cartesian-canvas.tsx
+++ b/frontend/src/components/dither/cartesian-canvas.tsx
@@ -1,0 +1,398 @@
+"use client"
+
+import { type RefObject, useEffect, useMemo, useRef } from "react"
+import { type ChartContextValue, useChart } from "./chart-context"
+import {
+  backingSize,
+  bloomLayerStyle,
+  easeInOutCubic,
+  paintColumn,
+  prefersReducedMotion,
+  resample,
+} from "./dither-paint"
+import { rgb } from "./palette"
+
+type Star = { key: string; xi: number; depth: number; phase: number }
+type Surface = { top: number[]; floor: number[] }
+
+type LoopArgs = {
+  canvas: HTMLCanvasElement
+  bloomCanvas: HTMLCanvasElement | null
+  cols: number
+  rows: number
+  state: RefObject<ChartContextValue>
+  targets: RefObject<Record<string, Surface>>
+  stars: RefObject<Star[]>
+}
+
+/**
+ * The requestAnimationFrame paint loop — eases each series toward its target
+ * surface, paints the dither fill (with the entrance reveal), then layers the
+ * crosshair marker and winking stars on top. Lives outside the component so the
+ * component stays small and this hot closure isn't re-created on every render.
+ * Returns a cleanup that cancels the loop.
+ */
+function startCartesianLoop({
+  canvas,
+  bloomCanvas,
+  cols,
+  rows,
+  state,
+  targets,
+  stars,
+}: LoopArgs): (() => void) | undefined {
+  const c = canvas.getContext("2d")
+  if (!c || cols <= 0 || rows <= 0) return undefined
+  canvas.width = cols
+  canvas.height = rows
+
+  const off = document.createElement("canvas")
+  off.width = cols
+  off.height = rows
+  const octx = off.getContext("2d")
+  if (!octx) return undefined
+
+  // Bloom layer: a blurred, additive copy of the crisp canvas.
+  const bloomCtx = bloomCanvas?.getContext("2d") ?? null
+  if (bloomCanvas) {
+    bloomCanvas.width = cols
+    bloomCanvas.height = rows
+  }
+
+  const reduce = prefersReducedMotion()
+  const EASE = reduce ? 1 : 0.18
+  const animate = state.current.animate && !reduce
+  const duration = state.current.animationDuration
+  const current: Record<string, Surface> = {}
+
+  // `reveal` (0–1) sweeps the fill in left-to-right on first paint.
+  const paintFill = (intensity: number, reveal: number) => {
+    octx.clearRect(0, 0, cols, rows)
+    const s = state.current
+    const stacked = s.stackType === "stacked" || s.stackType === "percent"
+    const revealCols = Math.ceil(reveal * cols)
+    s.configKeys.forEach((key, si) => {
+      const cur = current[key]
+      if (!cur) return
+      const seed = s.seedOf(key)
+      const variant = s.seriesSpecs[key]?.variant ?? "gradient"
+      const isLine =
+        (s.seriesSpecs[key]?.kind ??
+          (s.chartType === "line" ? "line" : "area")) === "line"
+      const emphasis = s.selectedDataKey ?? s.focusDataKey
+      const dim = emphasis !== null && emphasis !== key ? 0.3 : 1
+      // Overlapping (non-stacked) layers thin out front-to-back so they
+      // read as distinct layers instead of a muddy blend.
+      const sparse = stacked ? 0 : si * 0.14
+      for (let x = 0; x < cols; x++) {
+        if (x > revealCols) break
+        paintColumn(octx, x, cur.top[x] ?? 0, cur.floor[x] ?? 0, seed, {
+          variant,
+          intensity,
+          dim,
+          stacked: stacked && !isLine,
+          sparse,
+        })
+      }
+    })
+  }
+
+  let raf = 0
+  let tick = 0
+  let last = 0
+  let animStart = 0
+  let lastProg = -1
+  let lastRevision = state.current.revision
+  let entranceReported = !animate
+  let intensity = 0
+  let needsFill = true
+  let lastPaintSig = ""
+  let lastSelected: string | null | undefined = Symbol() as never
+
+  const draw = (now: number) => {
+    raf = requestAnimationFrame(draw)
+    const s = state.current
+    if (!s.ready) return
+    // Keep the bloom layer in sync with the crisp canvas while it's active.
+    if (bloomCtx) {
+      const on =
+        s.bloom !== "off" && (!s.bloomOnHover || s.isMouseInChart || s.hovered)
+      if (on) {
+        bloomCtx.clearRect(0, 0, cols, rows)
+        bloomCtx.drawImage(canvas, 0, 0)
+      }
+    }
+    const tgt = targets.current
+    if (s.revision !== lastRevision) {
+      lastRevision = s.revision
+      animStart = 0 // re-play the entrance on data change / replay
+      lastProg = -1
+      entranceReported = false
+    }
+    if (!animStart) animStart = now
+    const prog = animate ? Math.min(1, (now - animStart) / duration) : 1
+    const progChanged = prog !== lastProg
+    // Tell the context the reveal is done so DOM markers fade in in sync.
+    if (prog >= 1 && !entranceReported) {
+      entranceReported = true
+      s.markEntranceDone()
+    }
+
+    let moving = false
+    for (const key of s.configKeys) {
+      const t = tgt[key]
+      if (!t) continue
+      const cur = current[key]
+      if (!cur || cur.top.length !== cols) {
+        current[key] = { top: t.top.slice(), floor: t.floor.slice() }
+        needsFill = true
+        continue
+      }
+      for (let x = 0; x < cols; x++) {
+        const dt = t.top[x] - cur.top[x]
+        const df = t.floor[x] - cur.floor[x]
+        if (Math.abs(dt) > 0.01 || Math.abs(df) > 0.01) {
+          cur.top[x] += dt * EASE
+          cur.floor[x] += df * EASE
+          moving = true
+        } else {
+          cur.top[x] = t.top[x]
+          cur.floor[x] = t.floor[x]
+        }
+      }
+    }
+    for (const key of Object.keys(current)) {
+      if (!tgt[key]) {
+        delete current[key]
+        needsFill = true
+      }
+    }
+    if (moving) needsFill = true
+    const emphasisNow = s.selectedDataKey ?? s.focusDataKey
+    if (emphasisNow !== lastSelected) {
+      lastSelected = emphasisNow
+      needsFill = true
+    }
+
+    const itTarget = s.isMouseInChart || s.hovered ? 1 : 0
+    let settling = false
+    if (Math.abs(intensity - itTarget) > 0.001) {
+      intensity += (itTarget - intensity) * 0.16
+      settling = true
+      needsFill = true
+    } else intensity = itTarget
+
+    // Live hover wins; the controlled markerIndex (e.g. a committed point)
+    // is the fallback shown when nothing is hovered.
+    const marker = s.hoverIndex != null ? s.hoverIndex : s.markerIndex
+    const winkDue = !reduce && now - last >= 100
+    // Repaint when a tweak-driven paint input changes (variant, stacking) so
+    // the panel updates the fill live — without resetting the entrance reveal.
+    const paintSig = `${s.stackType}|${s.configKeys
+      .map((k) => s.seriesSpecs[k]?.variant ?? "")
+      .join(",")}`
+    const sigChanged = paintSig !== lastPaintSig
+    if (sigChanged) {
+      lastPaintSig = paintSig
+      needsFill = true
+    }
+    if (
+      !(
+        moving ||
+        settling ||
+        winkDue ||
+        marker != null ||
+        progChanged ||
+        sigChanged
+      )
+    )
+      return
+    if (progChanged) {
+      lastProg = prog
+      needsFill = true
+    }
+    if (winkDue) {
+      last = now
+      tick += 1
+    }
+
+    // Reveal front (left-to-right) — stars + crosshair stay behind it so
+    // they don't float over the not-yet-drawn area during the entrance.
+    const reveal = animate ? easeInOutCubic(prog) : 1
+    const revealCols = reveal * cols
+
+    if (needsFill) {
+      paintFill(intensity, reveal)
+      needsFill = false
+    }
+    c.clearRect(0, 0, cols, rows)
+    c.drawImage(off, 0, 0)
+
+    const mx =
+      marker != null && s.dataLength > 1
+        ? Math.round((marker / (s.dataLength - 1)) * (cols - 1))
+        : -1
+    if (mx >= 0 && mx <= revealCols) {
+      for (const key of s.configKeys) {
+        const cur = current[key]
+        if (!cur) continue
+        const seed = s.seedOf(key)
+        const my = Math.round(cur.top[mx] ?? 0)
+        // Full-height column + a chunky marker block at the point — the
+        // series colour at higher opacity, so it reads on either theme.
+        c.fillStyle = rgb(seed.fill, 1, 0.55)
+        for (let y = my; y < rows; y++) c.fillRect(mx, y, 1, 1)
+        c.fillStyle = rgb(seed.fill)
+        c.fillRect(mx - 1, my - 1, 3, 3)
+      }
+    }
+
+    for (const star of stars.current) {
+      const cur = current[star.key]
+      if (!cur) continue
+      const sx = Math.round(
+        (star.xi / Math.max(s.dataLength - 1, 1)) * (cols - 1)
+      )
+      if (sx > revealCols) continue // behind the reveal front
+      const top = cur.top[sx] ?? 0
+      const floor = cur.floor[sx] ?? rows - 1
+      const sy = Math.round(top + star.depth * (floor - top))
+      const tw = reduce ? 0.85 : (Math.sin((tick + star.phase) * 0.35) + 1) / 2
+      const lift = tw * (0.7 + 0.3 * intensity)
+      if (lift < 0.55 || sy < 0 || sy >= rows) continue
+      // Sparkles glint in the series colour via opacity (the `lift` wink)
+      // rather than a lighter shade — so they never read as stray white
+      // pixels on a light background.
+      const starColor = s.seedOf(star.key).fill
+      c.fillStyle = rgb(starColor, 1, lift)
+      c.fillRect(sx, sy, 1, 1)
+      // At the peak of a wink the star flares into a 4-point glint.
+      if (tw > 0.9) {
+        c.fillStyle = rgb(starColor, 1, lift * 0.6 * (tw - 0.9) * 10)
+        c.fillRect(sx - 1, sy, 1, 1)
+        c.fillRect(sx + 1, sy, 1, 1)
+        c.fillRect(sx, sy - 1, 1, 1)
+        c.fillRect(sx, sy + 1, 1, 1)
+      }
+    }
+  }
+
+  raf = requestAnimationFrame(draw)
+  return () => cancelAnimationFrame(raf)
+}
+
+/**
+ * Continuous dither canvas for area and line charts. Each series is reduced to a
+ * `[top, floor]` band per backing column: areas fill from their value line down
+ * to their floor; lines fill only a thin glow band hugging the line. The shared
+ * {@link paintColumn} renders the ordered-dither scatter, capped by the bright
+ * series line, with winking stars + scrub crosshair on top.
+ */
+export function CartesianCanvas() {
+  const ctx = useChart()
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const bloomRef = useRef<HTMLCanvasElement>(null)
+
+  const { width, height } = ctx.plot
+  const { cols, rows } = backingSize(width, height)
+  const { ready, chartType, configKeys, bands, seriesSpecs, y, dataLength } = ctx
+
+  // Memoized: the pricey bit in the render path — a `resample` per series to
+  // the backing column count. The canvas re-renders on every hover/cursor tick
+  // (it consumes ctx), so without this the whole surface is rebuilt each time.
+  // Pinned to the exact ctx fields it reads, plus the backing geometry.
+  const targets = useMemo(() => {
+    const out: Record<string, Surface> = {}
+    if (!ready) return out
+    const h = height || 1
+    const glow = Math.max(6, Math.round(rows * 0.16))
+    const defaultKind = chartType === "line" ? "line" : "area"
+    for (const key of configKeys) {
+      const band = bands[key]
+      if (!band) continue
+      const line = (seriesSpecs[key]?.kind ?? defaultKind) === "line"
+      const top = band.map((b) => (y(b[1]) / h) * (rows - 1))
+      const floor = band.map((b, i) =>
+        line ? Math.min(rows - 1, top[i] + glow) : (y(b[0]) / h) * (rows - 1)
+      )
+      out[key] = { top: resample(top, cols), floor: resample(floor, cols) }
+    }
+    return out
+  }, [ready, chartType, configKeys, bands, seriesSpecs, y, height, rows, cols])
+
+  // Memoized: the star field is deterministic — only its shape (series ×
+  // column count) matters, so it need not be rebuilt on unrelated re-renders.
+  const stars = useMemo(() => {
+    const out: Star[] = []
+    const per = Math.max(4, Math.round(cols / 14))
+    configKeys.forEach((key, k) => {
+      for (let i = 0; i < per; i++) {
+        const seed = i * 67 + 13 + k * 131
+        out.push({
+          key,
+          xi: seed % Math.max(dataLength, 1),
+          depth: ((seed * 53 + 7) % 100) / 100,
+          phase: (seed * 41) % 360,
+        })
+      }
+    })
+    return out
+  }, [configKeys, dataLength, cols])
+
+  // The RAF loop reads these through refs so it always sees the latest values
+  // without re-subscribing. Refs are written in an effect (never during
+  // render) — mutating a ref mid-render is a React anti-pattern that tears
+  // under Strict Mode / concurrent rendering.
+  const stateRef = useRef(ctx)
+  const targetsRef = useRef(targets)
+  const starsRef = useRef(stars)
+  useEffect(() => {
+    stateRef.current = ctx
+    targetsRef.current = targets
+    starsRef.current = stars
+  })
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    return startCartesianLoop({
+      canvas,
+      bloomCanvas: bloomRef.current,
+      cols,
+      rows,
+      state: stateRef,
+      targets: targetsRef,
+      stars: starsRef,
+    })
+  }, [cols, rows])
+
+  const bloomActive = ctx.bloomOnHover
+    ? ctx.isMouseInChart || ctx.hovered
+    : true
+  const bloom = bloomLayerStyle(ctx.bloom, bloomActive)
+  const pos = {
+    left: ctx.margins.left,
+    top: ctx.margins.top,
+    width,
+    height,
+  } as const
+
+  return (
+    <>
+      <canvas
+        ref={canvasRef}
+        className="pointer-events-none absolute"
+        style={{ ...pos, imageRendering: "pixelated" }}
+      />
+      <canvas
+        ref={bloomRef}
+        className="pointer-events-none absolute"
+        style={{
+          ...pos,
+          transition: "opacity 220ms ease",
+          ...(bloom ?? { opacity: 0 }),
+        }}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/dither/cartesian-root.tsx
+++ b/frontend/src/components/dither/cartesian-root.tsx
@@ -1,0 +1,193 @@
+"use client"
+
+import {
+  Children,
+  type ComponentType,
+  isValidElement,
+  type ReactNode,
+} from "react"
+import {
+  type ChartConfig,
+  ChartContext,
+  type ChartType,
+  type Margins,
+  useChartController,
+} from "./chart-context"
+import { CommonChartContext } from "./common-context"
+import type { BloomInput } from "./dither-paint"
+import { cn } from "./lib"
+import "./dither.css"
+import type { StackType } from "./scales"
+import { useChartDimensions } from "./use-chart-dimensions"
+
+// `object` rather than `Record<string, unknown>`: interfaces don't get an
+// implicit index signature, so interface-typed rows failed to satisfy the
+// generic. Internal layers still index rows through their own Row type.
+type Row = object
+
+const DEFAULT_MARGINS: Margins = {
+  top: 10,
+  right: 12,
+  bottom: 22,
+  left: 36,
+}
+
+export type CartesianChartProps<TData extends Row> = {
+  data: TData[]
+  config: ChartConfig
+  children: ReactNode
+  stackType?: StackType
+  margins?: Partial<Margins>
+  className?: string
+  animate?: boolean
+  animationDuration?: number
+  replayToken?: number // change to re-play the entrance without remounting
+  /** Set false for a decorative sparkline: keeps the hover lift but no scrub
+   * crosshair / tooltip. */
+  interactive?: boolean
+  /** Controlled crosshair position (e.g. a committed point) — overrides the
+   * internal hover when set. */
+  markerIndex?: number | null
+  /** Parent-driven hover (e.g. the whole card/row) — lifts the fill. */
+  hovered?: boolean
+  /** Glow on the dither fill. */
+  bloom?: BloomInput
+  /** Only bloom while the chart is hovered. */
+  bloomOnHover?: boolean
+  /** Fires with the scrubbed index as the pointer moves (null on leave). */
+  onHoverChange?: (index: number | null) => void
+  defaultSelectedDataKey?: string | null
+  onSelectionChange?: (key: string | null) => void
+}
+
+/** Which render layer a composed part targets — defaults to the front SVG. */
+function layerOf(node: ReactNode): "back" | "dom" | "svg" {
+  if (!isValidElement(node) || typeof node.type === "string") return "svg"
+  return (node.type as { chartLayer?: "back" | "dom" }).chartLayer ?? "svg"
+}
+
+/**
+ * Shared root for the cartesian dither charts (area, line, bar). Owns the
+ * measured size, the shared context, and pointer interaction; every visual is
+ * composed as children. Back chrome (grid) sits behind the dither canvas; the
+ * canvas paints the fill/line/bars + stars; front chrome (axes, dots) and DOM
+ * legend/tooltip layer on top. `chartType` drives the scales/interaction and the
+ * `Canvas` prop supplies the family's painter (continuous for area/line, bars for
+ * bar) — so each chart ships only its own canvas.
+ */
+export function CartesianRoot<TData extends Row>({
+  chartType,
+  Canvas,
+  data,
+  config,
+  children,
+  stackType = "default",
+  margins: marginsProp,
+  className,
+  animate = true,
+  animationDuration = 900,
+  replayToken = 0,
+  interactive = true,
+  markerIndex = null,
+  hovered = false,
+  bloom = "off",
+  bloomOnHover = false,
+  onHoverChange,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+}: CartesianChartProps<TData> & {
+  chartType: ChartType
+  Canvas: ComponentType
+}) {
+  const { ref, size } = useChartDimensions<HTMLDivElement>()
+  const margins = { ...DEFAULT_MARGINS, ...marginsProp }
+
+  const ctx = useChartController({
+    chartType,
+    // Safe: the controller only reads row[key] for the configured series keys.
+    data: data as Record<string, unknown>[],
+    config,
+    stackType,
+    dimensions: size,
+    margins,
+    animate,
+    animationDuration,
+    replayToken,
+    markerIndex,
+    hovered,
+    bloom,
+    bloomOnHover,
+    defaultSelectedDataKey,
+    onSelectionChange,
+  })
+
+  const backChildren: ReactNode[] = []
+  const svgChildren: ReactNode[] = []
+  const domChildren: ReactNode[] = []
+  Children.forEach(children, (child) => {
+    const layer = layerOf(child)
+    if (layer === "back") backChildren.push(child)
+    else if (layer === "dom") domChildren.push(child)
+    else svgChildren.push(child)
+  })
+
+  const onMove = (clientX: number) => {
+    const el = ref.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    const px = clientX - rect.left - margins.left
+    const index = ctx.indexAtX(px)
+    ctx.setHoverIndex(index)
+    ctx.setCursorX(clientX - rect.left)
+    onHoverChange?.(index)
+  }
+
+  return (
+    <ChartContext value={ctx}>
+      <CommonChartContext value={ctx.common}>
+        <div
+          ref={ref}
+          className={cn("dither-root relative h-full w-full", className)}
+          onPointerEnter={() => ctx.setMouseInChart(true)}
+          onPointerMove={interactive ? (e) => onMove(e.clientX) : undefined}
+          onPointerLeave={() => {
+            ctx.setMouseInChart(false)
+            ctx.setHoverIndex(null)
+            onHoverChange?.(null)
+          }}
+        >
+          {ctx.ready && backChildren.length > 0 && (
+            <svg
+              width={size.width}
+              height={size.height}
+              className="absolute inset-0 overflow-visible"
+              aria-hidden
+              role="presentation"
+            >
+              <g transform={`translate(${margins.left},${margins.top})`}>
+                {backChildren}
+              </g>
+            </svg>
+          )}
+          <Canvas />
+          {ctx.ready && (
+            <svg
+              width={size.width}
+              height={size.height}
+              className="absolute inset-0 overflow-visible"
+              role="img"
+              aria-label="Chart"
+            >
+              <g transform={`translate(${margins.left},${margins.top})`}>
+                {svgChildren}
+              </g>
+            </svg>
+          )}
+          {domChildren}
+        </div>
+      </CommonChartContext>
+    </ChartContext>
+  )
+}
+
+export type AreaChartProps<TData extends Row> = CartesianChartProps<TData>

--- a/frontend/src/components/dither/chart-context.tsx
+++ b/frontend/src/components/dither/chart-context.tsx
@@ -1,0 +1,504 @@
+"use client"
+
+import type { ScaleLinear } from "d3-scale"
+import { createContext, use, useCallback, useMemo, useState } from "react"
+import type { CommonChart } from "./common-context"
+import type { BloomInput } from "./dither-paint"
+import type { DitherColor, Seed } from "./palette"
+import { seedOfColor } from "./palette"
+import {
+  buildBandScale,
+  buildXScale,
+  buildYScale,
+  computeBands,
+  indexAtBand,
+  nearestIndex,
+  type StackType,
+} from "./scales"
+import type { Dimensions } from "./use-chart-dimensions"
+
+/** Which chart root a part is composed under — drives the boundary guards. */
+export type ChartType = "area" | "bar" | "line" | "pie" | "radar"
+
+export type ChartConfig = Record<string, { label?: string; color: DitherColor }>
+
+export type Margins = {
+  top: number
+  right: number
+  bottom: number
+  left: number
+}
+
+type Row = Record<string, unknown>
+
+export type AreaVariant = "gradient" | "dotted" | "hatched" | "solid"
+export type StrokeVariant = "solid" | "dashed"
+export type SeriesKind = "area" | "line" | "bar"
+
+/** What each series part (<Area />, <Line />, <Bar />) registers so the canvas
+ * knows which series to paint and how. */
+export type SeriesSpec = {
+  dataKey: string
+  kind: SeriesKind
+  variant: AreaVariant
+  strokeVariant: StrokeVariant
+}
+
+export type ChartContextValue = {
+  chartType: ChartType // which root this part is under
+  config: ChartConfig
+  configKeys: string[] // series order — drives stacking + legend
+  data: Row[]
+  dataLength: number
+  stackType: StackType
+
+  margins: Margins
+  plot: { width: number; height: number } // inner drawing area
+  ready: boolean // true once measured (width > 0)
+
+  xCenter: (index: number) => number // category centre px within the plot
+  bandwidth: number // category slot width (0 for point/area scales)
+  indexAtX: (px: number) => number // nearest category for a pointer x
+  // Bar geometry in plot px — one source of truth for the canvas + click rects.
+  barSlot: (
+    index: number,
+    seriesIndex: number,
+    seriesCount: number
+  ) => { x: number; width: number }
+  y: ScaleLinear<number, number> // value → px within the plot
+  bands: Record<string, [number, number][]> // per-series [y0, y1] per row
+  max: number
+
+  // Interaction state, shared by every part.
+  selectedDataKey: string | null
+  selectDataKey: (key: string | null) => void
+  /** Legend-hover spotlight — dims every series but this one while set. */
+  focusDataKey: string | null
+  setFocusDataKey: (key: string | null) => void
+  hoverIndex: number | null
+  setHoverIndex: (index: number | null) => void
+  markerIndex: number | null // controlled crosshair override (e.g. committed point)
+  cursorX: number
+  setCursorX: (px: number) => void
+  isMouseInChart: boolean
+  setMouseInChart: (over: boolean) => void
+  hovered: boolean // parent-driven hover (e.g. the whole card) — lifts the fill
+  bloom: BloomInput // glow on the dither canvas
+  bloomOnHover: boolean // only bloom while hovered
+
+  // Series register themselves so the canvas knows what (and how) to paint.
+  seriesSpecs: Record<string, SeriesSpec>
+  registerSeries: (spec: SeriesSpec) => void
+  unregisterSeries: (dataKey: string) => void
+
+  // Entrance animation (prop-driven). `revision` bumps when the data changes or
+  // the replay token advances, so the canvas can re-play its entrance.
+  animate: boolean
+  animationDuration: number
+  revision: number
+  entranceDone: boolean // true once the entrance has played — gates SVG markers
+  markEntranceDone: () => void // the canvas calls this when its reveal completes
+
+  // Helpers.
+  seedOf: (key: string) => Seed
+  common: CommonChart // shared surface for <Legend> / <Tooltip>
+}
+
+const ChartContext = createContext<ChartContextValue | null>(null)
+
+const ROOT_OF: Record<ChartType, string> = {
+  area: "<AreaChart />",
+  bar: "<BarChart />",
+  line: "<LineChart />",
+  pie: "<PieChart />",
+  radar: "<RadarChart />",
+}
+
+/** Generic accessor for internal layers (canvas/overlay) that work for any root. */
+export function useChart() {
+  const ctx = use(ChartContext)
+  if (!ctx) {
+    throw new Error(
+      "Chart parts must be used within a chart root (e.g. <AreaChart />)."
+    )
+  }
+  return ctx
+}
+
+/**
+ * Boundary guard for a composable part. Throws a precise error when used outside
+ * a root, or inside the wrong chart type — e.g. `<Bar />` placed in an area
+ * chart. `kind` omitted means the part works under any root (grid, axes, …).
+ */
+export function useChartPart(
+  part: string,
+  kind?: ChartType | ChartType[]
+): ChartContextValue {
+  const ctx = use(ChartContext)
+  if (!ctx) {
+    const where = kind
+      ? ROOT_OF[Array.isArray(kind) ? kind[0] : kind]
+      : "a chart root"
+    throw new Error(`<${part} /> must be used within ${where}.`)
+  }
+  if (kind) {
+    const allowed = Array.isArray(kind) ? kind : [kind]
+    if (!allowed.includes(ctx.chartType)) {
+      throw new Error(
+        `<${part} /> is not valid inside ${ROOT_OF[ctx.chartType]} — it belongs in ${allowed
+          .map((k) => ROOT_OF[k])
+          .join(" or ")}.`
+      )
+    }
+  }
+  return ctx
+}
+
+export { ChartContext }
+
+/** A counter that advances whenever `data` changes identity or `token` advances
+ * — drives entrance replays without remounting. Uses the adjust-state-during-
+ * render pattern (https://react.dev/reference/react/useState) instead of a ref:
+ * the revision is derived purely from render inputs, so it stays consistent
+ * across the memoized values below rather than lagging a render behind. */
+export function useRevision(data: unknown, token: number) {
+  const [prev, setPrev] = useState({ data, token, revision: 0 })
+  if (prev.data !== data || prev.token !== token) {
+    const next = { data, token, revision: prev.revision + 1 }
+    setPrev(next)
+    return next.revision
+  }
+  return prev.revision
+}
+
+/**
+ * Builds the shared context value: resolves the plot rect from the measured
+ * size minus margins, computes the x/y scales and the per-series stack bands,
+ * and owns the selection + hover state every part reads.
+ */
+export function useChartController({
+  chartType,
+  data,
+  config,
+  stackType,
+  dimensions,
+  margins,
+  animate = true,
+  animationDuration = 900,
+  replayToken = 0,
+  markerIndex = null,
+  hovered = false,
+  bloom = "off",
+  bloomOnHover = false,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+}: {
+  chartType: ChartType
+  data: Row[]
+  config: ChartConfig
+  stackType: StackType
+  dimensions: Dimensions
+  margins: Margins
+  animate?: boolean
+  animationDuration?: number
+  replayToken?: number
+  markerIndex?: number | null
+  hovered?: boolean
+  bloom?: BloomInput
+  bloomOnHover?: boolean
+  defaultSelectedDataKey?: string | null
+  onSelectionChange?: (key: string | null) => void
+}): ChartContextValue {
+  // This object becomes the ChartContext value, so its identity — and the
+  // identity of every function/object it carries — must stay stable across
+  // renders that don't change the underlying inputs. Otherwise every consumer
+  // (axes, legend, tooltip, dots) re-renders on every parent render. So the
+  // expensive derivations, the exposed callbacks, and the returned value are
+  // memoized below; only cheap scalars (bandwidth, ready, plot sizes) are left
+  // bare, since they're just recomputed reads, not identities anyone depends on.
+
+  // Memoized: configKeys is the dep that drives `bands`, `common` and the
+  // canvas `targets` memo — a fresh array each render would bust all of them.
+  const configKeys = useMemo(() => Object.keys(config), [config])
+  const revision = useRevision(data, replayToken)
+
+  const [selectedDataKey, setSelectedDataKey] = useState<string | null>(
+    defaultSelectedDataKey
+  )
+  const [focusDataKey, setFocusDataKey] = useState<string | null>(null)
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null)
+  const [cursorX, setCursorX] = useState(0)
+  const [isMouseInChart, setMouseInChart] = useState(false)
+  const [seriesSpecs, setSeriesSpecs] = useState<Record<string, SeriesSpec>>({})
+
+  // useCallback because the series effects in area.tsx/bar.tsx list these as
+  // deps — without stable identities the unregister/register effect re-fires
+  // every render and its setState pair loops ("Maximum update depth exceeded").
+  const registerSeries = useCallback((spec: SeriesSpec) => {
+    setSeriesSpecs((prev) => {
+      const cur = prev[spec.dataKey]
+      return cur &&
+        cur.kind === spec.kind &&
+        cur.variant === spec.variant &&
+        cur.strokeVariant === spec.strokeVariant
+        ? prev
+        : { ...prev, [spec.dataKey]: spec }
+    })
+  }, [])
+  const unregisterSeries = useCallback((dataKey: string) => {
+    setSeriesSpecs((prev) => {
+      if (!(dataKey in prev)) return prev
+      const next = { ...prev }
+      delete next[dataKey]
+      return next
+    })
+  }, [])
+
+  // Stable so the memoized value keeps its identity; only re-created when the
+  // caller's selection handler does.
+  const selectDataKey = useCallback(
+    (key: string | null) => {
+      setSelectedDataKey(key)
+      onSelectionChange?.(key)
+    },
+    [onSelectionChange]
+  )
+
+  // The root spreads `{ ...DEFAULT_MARGINS, ...marginsProp }` fresh every
+  // render, so `margins` never keeps its identity. Pin one off the four numbers
+  // so it doesn't, on its own, invalidate the value or the plot geometry.
+  const { top: mTop, right: mRight, bottom: mBottom, left: mLeft } = margins
+  const stableMargins = useMemo(
+    () => ({ top: mTop, right: mRight, bottom: mBottom, left: mLeft }),
+    [mTop, mRight, mBottom, mLeft]
+  )
+
+  const plotWidth = Math.max(0, dimensions.width - mLeft - mRight)
+  const plotHeight = Math.max(0, dimensions.height - mTop - mBottom)
+  const ready = plotWidth > 0 && plotHeight > 0
+
+  // The entrance gate flips true when the canvas reveal completes (via
+  // `markEntranceDone`) so DOM markers fade in with the fill, and re-arms on
+  // each replay. Adjust-state-during-render instead of an effect, so the reset
+  // lands in the same render as the revision bump.
+  const [entrance, setEntrance] = useState({ revision, done: !animate })
+  if (entrance.revision !== revision) {
+    setEntrance({ revision, done: !animate })
+  }
+  const entranceDone = entrance.revision === revision ? entrance.done : !animate
+  // Stable across renders at the same revision; the canvas holds this in a ref.
+  const markEntranceDone = useCallback(
+    () => setEntrance({ revision, done: true }),
+    [revision]
+  )
+
+  // Memoized: the priciest derivation in the render path — it walks every
+  // row × series to build the stack bands. Hover/cursor state changes must not
+  // recompute it, only a real data/series/stack change.
+  const { bands, max } = useMemo(
+    () => computeBands(data, configKeys, stackType),
+    [data, configKeys, stackType]
+  )
+
+  const isBar = chartType === "bar"
+  // The d3 scale factories are memoized so `y` keeps a stable identity: the
+  // canvas `targets` memo (cartesian-canvas / bar-canvas) deps on ctx.y, and
+  // xCenter/indexAtX/barSlot below close over these.
+  const xPoint = useMemo(
+    () => buildXScale(data.length, plotWidth),
+    [data.length, plotWidth]
+  )
+  const xBand = useMemo(
+    () => buildBandScale(data.length, plotWidth),
+    [data.length, plotWidth]
+  )
+  const bandwidth = isBar ? xBand.bandwidth() : 0
+  const xCenter = useCallback(
+    (i: number) =>
+      isBar ? (xBand(i) ?? 0) + xBand.bandwidth() / 2 : (xPoint(i) ?? 0),
+    [isBar, xBand, xPoint]
+  )
+  const indexAtX = useCallback(
+    (px: number) =>
+      isBar
+        ? indexAtBand(px, data.length, plotWidth)
+        : nearestIndex(px, data.length, plotWidth),
+    [isBar, data.length, plotWidth]
+  )
+  const stacked = stackType === "stacked" || stackType === "percent"
+  const barSlot = useCallback(
+    (i: number, si: number, n: number) => {
+      const center = xCenter(i)
+      if (stacked) {
+        const w = bandwidth * 0.9
+        return { x: center - w / 2, width: w }
+      }
+      const slot = bandwidth / Math.max(n, 1)
+      return {
+        x: center - bandwidth / 2 + si * slot + slot * 0.08,
+        width: slot * 0.84,
+      }
+    },
+    [xCenter, stacked, bandwidth]
+  )
+  const y = useMemo(() => buildYScale(max, plotHeight), [max, plotHeight])
+
+  // Stable so `common` and the value stay stable; re-created only on config.
+  const seedOf = useCallback(
+    (key: string) => seedOfColor(config[key]?.color ?? "grey"),
+    [config]
+  )
+
+  // Memoized: this is the value handed to CommonChartContext (Legend/Tooltip),
+  // so it needs its own stable identity independent of the parent value.
+  const common: CommonChart = useMemo(() => ({
+    names: configKeys,
+    labelOf: (n) => config[n]?.label ?? n,
+    seedOf,
+    selectedDataKey,
+    selectDataKey,
+    focusDataKey,
+    setFocusDataKey,
+    hoverIndex,
+    ready,
+    tooltipLeft: Math.max(48, Math.min(plotWidth + mLeft - 48, cursorX)),
+    // Follow the highest hovered node so the card rides the data path, but
+    // keep enough headroom that the upward-lifted card never clips the top.
+    tooltipTop: (() => {
+      const floor = mTop + 44
+      if (hoverIndex == null) return floor
+      let minY = Number.POSITIVE_INFINITY
+      for (const key of configKeys) {
+        const b = bands[key]?.[hoverIndex]
+        if (b) minY = Math.min(minY, y(b[1]))
+      }
+      if (!Number.isFinite(minY)) return floor
+      return Math.max(floor, mTop + minY)
+    })(),
+    heading: (i, labelKey) =>
+      labelKey ? String(data[i]?.[labelKey] ?? "") : null,
+    itemsAt: (i) =>
+      configKeys.map((name) => {
+        const raw = data[i]?.[name]
+        return {
+          name,
+          label: config[name]?.label ?? name,
+          value: typeof raw === "number" ? raw : 0,
+          seed: seedOf(name),
+          dimmed: (() => {
+            const emphasis = selectedDataKey ?? focusDataKey
+            return emphasis !== null && emphasis !== name
+          })(),
+        }
+      }),
+  }), [
+    configKeys,
+    config,
+    seedOf,
+    selectedDataKey,
+    selectDataKey,
+    focusDataKey,
+    setFocusDataKey,
+    hoverIndex,
+    ready,
+    plotWidth,
+    mLeft,
+    mTop,
+    cursorX,
+    bands,
+    y,
+    data,
+  ])
+
+  // Memoized: this is the ChartContext value. A fresh object here would
+  // re-render every consumer on every parent render — the whole reason the
+  // pieces above are stabilized. Rebuilds only when a listed input changes
+  // (which is exactly when a consumer needs the update). The useState setters
+  // are listed but never change identity, so they never trigger a rebuild.
+  return useMemo<ChartContextValue>(
+    () => ({
+      chartType,
+      config,
+      configKeys,
+      data,
+      dataLength: data.length,
+      stackType,
+      margins: stableMargins,
+      plot: { width: plotWidth, height: plotHeight },
+      ready,
+      xCenter,
+      bandwidth,
+      indexAtX,
+      barSlot,
+      y,
+      bands,
+      max,
+      selectedDataKey,
+      selectDataKey,
+      focusDataKey,
+      setFocusDataKey,
+      hoverIndex,
+      setHoverIndex,
+      markerIndex,
+      cursorX,
+      setCursorX,
+      isMouseInChart,
+      setMouseInChart,
+      hovered,
+      bloom,
+      bloomOnHover,
+      seriesSpecs,
+      registerSeries,
+      unregisterSeries,
+      animate,
+      animationDuration,
+      revision,
+      entranceDone,
+      markEntranceDone,
+      seedOf,
+      common,
+    }),
+    [
+      chartType,
+      config,
+      configKeys,
+      data,
+      stackType,
+      stableMargins,
+      plotWidth,
+      plotHeight,
+      ready,
+      xCenter,
+      bandwidth,
+      indexAtX,
+      barSlot,
+      y,
+      bands,
+      max,
+      selectedDataKey,
+      selectDataKey,
+      focusDataKey,
+      setFocusDataKey,
+      hoverIndex,
+      setHoverIndex,
+      markerIndex,
+      cursorX,
+      setCursorX,
+      isMouseInChart,
+      setMouseInChart,
+      hovered,
+      bloom,
+      bloomOnHover,
+      seriesSpecs,
+      registerSeries,
+      unregisterSeries,
+      animate,
+      animationDuration,
+      revision,
+      entranceDone,
+      markEntranceDone,
+      seedOf,
+      common,
+    ]
+  )
+}

--- a/frontend/src/components/dither/common-context.tsx
+++ b/frontend/src/components/dither/common-context.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { createContext, use } from "react"
+import type { Seed } from "./palette"
+
+/** A single tooltip row — one series (cartesian/radar) or one slice (pie). */
+export type TooltipItem = {
+  name: string
+  label: string
+  value: number
+  seed: Seed
+  dimmed: boolean
+}
+
+/**
+ * The minimal surface shared by every chart family, so `<Legend>` and
+ * `<Tooltip>` work identically whether they sit in a cartesian, bar, or polar
+ * root. Each root publishes one of these alongside its family-specific context.
+ */
+export type CommonChart = {
+  names: string[] // legend entries — series keys (cartesian) or slice names (pie)
+  labelOf: (name: string) => string
+  seedOf: (name: string) => Seed
+  selectedDataKey: string | null
+  selectDataKey: (key: string | null) => void
+  /** Transient legend-hover emphasis — spotlights one series (others dim)
+   * while the pointer rests on its legend entry. Selection still wins. */
+  focusDataKey: string | null
+  setFocusDataKey: (key: string | null) => void
+  hoverIndex: number | null
+  heading: (index: number, labelKey?: string) => string | null
+  itemsAt: (index: number) => TooltipItem[]
+  ready: boolean
+  tooltipLeft: number // clamped px for the floating tooltip
+  tooltipTop: number // px — follows the hovered node (cartesian) / cursor (polar)
+}
+
+export const CommonChartContext = createContext<CommonChart | null>(null)
+
+export function useCommonChart() {
+  const ctx = use(CommonChartContext)
+  if (!ctx) {
+    throw new Error(
+      "<Legend /> / <Tooltip /> must be used within a chart root."
+    )
+  }
+  return ctx
+}

--- a/frontend/src/components/dither/dither-heatmap.tsx
+++ b/frontend/src/components/dither/dither-heatmap.tsx
@@ -1,0 +1,167 @@
+// LOCAL EXTENSION — not part of upstream dither-kit. A day×hour heatmap in the
+// same ordered-dither texture, built on the kit's pixel primitives so it reads
+// as one family with the vendored charts. Replaces the former ECharts heatmaps.
+import { useEffect, useRef, useState } from "react"
+import { BAYER4, clamp01 } from "./pixel"
+import { type DitherColor, PALETTE, rgb } from "./palette"
+import "./dither.css"
+
+export interface DitherHeatmapCell {
+  day: number // 0 (Sun) – 6 (Sat)
+  hour: number // 0–23
+  winRate: number | null // 0–100, null = no data
+  games: number
+}
+
+export interface DitherHeatmapProps {
+  cells: DitherHeatmapCell[]
+  height?: number
+  lowColor?: DitherColor
+  highColor?: DitherColor
+  /** Label for the tooltip metric, e.g. "win rate" */
+  metricLabel?: string
+}
+
+const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+const LEFT = 36 // px reserved for day labels
+const BOTTOM = 18 // px reserved for hour labels
+const GAP = 2 // px between cells
+const DITHER = 2 // css px per dither cell (matches the kit's CELL)
+
+export function DitherHeatmap({
+  cells,
+  height = 260,
+  lowColor = "red",
+  highColor = "green",
+  metricLabel = "win rate",
+}: DitherHeatmapProps) {
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [width, setWidth] = useState(0)
+  const [hover, setHover] = useState<{
+    x: number
+    y: number
+    cell: DitherHeatmapCell
+  } | null>(null)
+
+  useEffect(() => {
+    const el = wrapRef.current
+    if (!el) return
+    const ro = new ResizeObserver(() => setWidth(el.clientWidth))
+    ro.observe(el)
+    setWidth(el.clientWidth)
+    return () => ro.disconnect()
+  }, [])
+
+  const maxGames = Math.max(1, ...cells.map((c) => c.games))
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas || width === 0) return
+    const dpr = window.devicePixelRatio || 1
+    canvas.width = Math.round(width * dpr)
+    canvas.height = Math.round(height * dpr)
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    ctx.clearRect(0, 0, width, height)
+
+    const gridW = width - LEFT
+    const gridH = height - BOTTOM
+    const cw = gridW / 24
+    const ch = gridH / 7
+
+    const low = PALETTE[lowColor]
+    const high = PALETTE[highColor]
+    const byPos = new Map(cells.map((c) => [`${c.day}-${c.hour}`, c]))
+
+    for (let day = 0; day < 7; day++) {
+      for (let hour = 0; hour < 24; hour++) {
+        const x0 = LEFT + hour * cw
+        const y0 = day * ch
+        const w = cw - GAP
+        const h = ch - GAP
+        const cell = byPos.get(`${day}-${hour}`)
+
+        if (!cell || cell.winRate == null || cell.games === 0) {
+          ctx.fillStyle = "rgba(80, 73, 69, 0.25)" // empty: faint gruvbox bg2
+          ctx.fillRect(x0, y0, w, h)
+          continue
+        }
+
+        const t = clamp01(cell.winRate / 100)
+        // More games -> denser, more confident cell
+        const weight = 0.55 + 0.45 * clamp01(cell.games / maxGames)
+        const cols = Math.max(1, Math.floor(w / DITHER))
+        const rows = Math.max(1, Math.floor(h / DITHER))
+        for (let cy = 0; cy < rows; cy++) {
+          for (let cx = 0; cx < cols; cx++) {
+            // Ordered dither: threshold decides low- vs high-seed pixel
+            const threshold = BAYER4[cy & 3][cx & 3]
+            const seed = t > threshold ? high : low
+            const bright = t > threshold ? t : 1 - t
+            ctx.fillStyle = rgb(seed.fill, 0.55 + 0.45 * bright, weight)
+            ctx.fillRect(
+              x0 + cx * DITHER,
+              y0 + cy * DITHER,
+              Math.min(DITHER, w - cx * DITHER),
+              Math.min(DITHER, h - cy * DITHER)
+            )
+          }
+        }
+      }
+    }
+
+    // Labels
+    ctx.fillStyle = "#a89984"
+    ctx.font = "10px ui-monospace, SFMono-Regular, Menlo, monospace"
+    ctx.textBaseline = "middle"
+    DAYS.forEach((d, i) => ctx.fillText(d, 0, i * ch + ch / 2))
+    ctx.textBaseline = "top"
+    for (let hour = 0; hour < 24; hour += 3) {
+      ctx.fillText(String(hour), LEFT + hour * cw, height - BOTTOM + 4)
+    }
+  }, [cells, width, height, lowColor, highColor, maxGames])
+
+  const handleMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect()
+    const px = e.clientX - rect.left
+    const py = e.clientY - rect.top
+    const cw = (width - LEFT) / 24
+    const ch = (height - BOTTOM) / 7
+    const hour = Math.floor((px - LEFT) / cw)
+    const day = Math.floor(py / ch)
+    if (hour < 0 || hour > 23 || day < 0 || day > 6) return setHover(null)
+    const cell = cells.find((c) => c.day === day && c.hour === hour)
+    if (!cell || cell.winRate == null || cell.games === 0) return setHover(null)
+    setHover({ x: px, y: py, cell })
+  }
+
+  return (
+    <div
+      ref={wrapRef}
+      className="dither-root"
+      style={{ height, position: "relative", width: "100%" }}
+    >
+      <canvas
+        ref={canvasRef}
+        style={{ width: "100%", height: "100%", display: "block" }}
+        onMouseMove={handleMove}
+        onMouseLeave={() => setHover(null)}
+      />
+      {hover && (
+        <div
+          className="pointer-events-none absolute z-10 rounded-md border bg-popover px-2 py-1 shadow-sm font-mono text-[11px] text-popover-foreground"
+          style={{
+            left: Math.min(hover.x + 10, width - 150),
+            top: Math.max(hover.y - 34, 0),
+          }}
+        >
+          {DAYS[hover.cell.day]} {String(hover.cell.hour).padStart(2, "0")}:00 —{" "}
+          {Math.round(hover.cell.winRate ?? 0)}% {metricLabel} (
+          {hover.cell.games} games)
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/dither/dither-paint.ts
+++ b/frontend/src/components/dither/dither-paint.ts
@@ -1,0 +1,181 @@
+// Shared ordered-dither painting primitives, used by every cartesian canvas
+// (area, line, bar). Keeping the Bayer threshold loop in one place means every
+// chart type reads with the exact same pixel texture.
+
+import type { AreaVariant } from "./chart-context"
+import { rgb, type Seed } from "./palette"
+
+// 4×4 ordered (Bayer) matrix, normalized to 0–1 thresholds — the exact matrix
+// the legacy chart dithers with.
+export const BAYER = [
+  [0, 8, 2, 10],
+  [12, 4, 14, 6],
+  [3, 11, 1, 9],
+  [15, 7, 13, 5],
+].map((row) => row.map((v) => (v + 0.5) / 16))
+
+export const CELL = 2 // css px per dither cell — chunky enough to read pixelated
+export const MAX_COLS = 520
+export const MAX_ROWS = 200
+// Opacity of the top border outline (just under solid, so it reads as a soft
+// edge rather than a hard line). See the note on colour vs opacity below.
+export const BORDER_ALPHA = 0.72
+// Opacity of a dither "off" cell relative to an "on" cell. The scatter modulates
+// between these two tiers of the *same* colour instead of leaving holes, so the
+// background never shows through as stark white on a light theme.
+export const OFF_TIER = 0.4
+
+export type PaintOpts = {
+  variant: AreaVariant
+  intensity: number // 0–1 hover lift
+  dim: number // selection dim multiplier (0.3 dimmed, 1 normal)
+  stacked: boolean // denser + solid floor when layers stack
+  sparse?: number // raise the dither threshold (thin out) — front layers
+}
+
+// Colour vs opacity — the guiding rule for the whole engine:
+//
+//   Work with opacities instead of different shades of the same color. This will
+//   make sure it looks good on both light and dark mode.
+//
+// So every pixel is the series' single `fill` colour and we vary only its alpha.
+// The old lighter `line` / near-white `star` shades were dropped: a shade that
+// pops on a dark background reads as a jarring bright speck on a light one, while
+// the same colour at a lower opacity simply blends into whatever sits behind it.
+
+/**
+ * Fill one backing-canvas column `x` from row `top` down to `floor` with the
+ * ordered-dither scatter — solid at the floor, dissolving upward so it *fades
+ * out toward the value line* — then cap the top with a soft border outline in
+ * the series colour. Density drives opacity (see the note above), so the fade
+ * reads correctly against both light and dark backgrounds. The single source of
+ * the dither look across area / line / bar.
+ */
+export function paintColumn(
+  octx: CanvasRenderingContext2D,
+  x: number,
+  top: number,
+  floor: number,
+  seed: Seed,
+  { variant, intensity, dim, stacked, sparse = 0 }: PaintOpts
+) {
+  const t = Math.round(top)
+  const f = Math.round(floor)
+  const depth = f - t
+  if (depth <= 0) {
+    octx.fillStyle = rgb(seed.fill, 1, BORDER_ALPHA * dim)
+    octx.fillRect(x, t, 1, 1)
+    return
+  }
+  const bias = (variant === "dotted" ? 0.12 : 0) + (stacked ? 0.2 : 0) - sparse
+  for (let y = t; y < f; y++) {
+    // Inverted falloff: 0 at the top line, 1 at the floor — dense at the
+    // bottom, thinning as it rises toward the outline.
+    let density = (y - t) / depth
+    if (stacked) density = 0.5 + 0.5 * density
+    if (variant === "hatched" && ((x + y) & 3) >= 2) continue
+    const lit =
+      variant === "solid" ||
+      density > BAYER[y & 3][x & 3] - 0.1 * intensity - bias
+    // "dotted" keeps real gaps for its open look; every other variant covers
+    // the cell and lets the dither ride the alpha (on = full tier, off = a
+    // faint tint) so nothing shows the background through as white.
+    if (variant === "dotted" && !lit) continue
+    // Density → alpha (see the colour-vs-opacity note above).
+    const k = (0.3 + density * 0.7) * (1 + 0.22 * intensity)
+    const alpha = clamp01((lit ? k : k * OFF_TIER) * dim)
+    octx.fillStyle = rgb(seed.fill, 1, alpha)
+    octx.fillRect(x, y, 1, 1)
+  }
+  // Top border outline — the shape's edge now that the fill fades out here.
+  // Kept just under full opacity, with a faint feather row beneath, so it reads
+  // as a soft edge rather than a hard line floating over the fade.
+  octx.fillStyle = rgb(seed.fill, 1, BORDER_ALPHA * dim)
+  octx.fillRect(x, t, 1, 1)
+  if (depth > 1) {
+    octx.fillStyle = rgb(seed.fill, 1, BORDER_ALPHA * 0.5 * dim)
+    octx.fillRect(x, t + 1, 1, 1)
+  }
+}
+
+/** Linear-resample a per-index fraction array to `cols` columns. */
+export function resample(src: number[], cols: number): number[] {
+  const out = new Array<number>(cols)
+  const last = Math.max(src.length - 1, 1)
+  for (let c = 0; c < cols; c++) {
+    const t = (c / Math.max(cols - 1, 1)) * last
+    const i = Math.floor(t)
+    const f = t - i
+    const a = src[i] ?? 0
+    const b = src[Math.min(i + 1, src.length - 1)] ?? a
+    out[c] = a + (b - a) * f
+  }
+  return out
+}
+
+/** Backing-canvas resolution for a plot rect — low-res, scaled up `pixelated`. */
+export function backingSize(width: number, height: number) {
+  return {
+    cols: Math.min(MAX_COLS, Math.max(8, Math.round(width / CELL))),
+    rows: Math.min(MAX_ROWS, Math.max(8, Math.round(height / CELL))),
+  }
+}
+
+// Bloom — a real "shader" glow that comes from the colours themselves: a blurred
+// copy of the rendered canvas, composited additively (`plus-lighter`) so each
+// hue blooms in its own colour instead of a grey wash. Lives on a second canvas
+// layered over the crisp one (which stays sharp/pixelated).
+export type BloomLevel = "off" | "low" | "high" | "aura"
+export type BloomBlend = "plus-lighter" | "screen" | "lighten"
+export type BloomConfig = {
+  blur: number // px
+  brightness: number // 1 = none
+  opacity: number // 0–1
+  /** Saturation of the glow — >1 keeps it vividly in the dither's colour
+   * instead of washing toward white. */
+  saturate?: number
+  blend?: BloomBlend // additive by default
+}
+/** A preset name, a full config, or "off". */
+export type BloomInput = BloomLevel | BloomConfig
+
+const PRESET: Record<Exclude<BloomLevel, "off">, BloomConfig> = {
+  low: { blur: 3, brightness: 1.35, opacity: 0.7, saturate: 1.4 },
+  high: { blur: 5, brightness: 1.5, opacity: 0.78, saturate: 1.5 },
+  aura: { blur: 15, brightness: 2.9, opacity: 0.1, saturate: 3 },
+}
+
+export type BloomStyle = {
+  filter: string
+  opacity: number
+  mixBlendMode: BloomBlend
+  imageRendering: "auto"
+}
+
+/** Style for the bloom *layer* canvas (a blurred, additive copy). null when off. */
+export function bloomLayerStyle(
+  input: BloomInput,
+  active: boolean
+): BloomStyle | null {
+  if (!active || input === "off") return null
+  const cfg = typeof input === "string" ? PRESET[input] : input
+  return {
+    filter: `blur(${cfg.blur}px) brightness(${cfg.brightness}) saturate(${cfg.saturate ?? 1})`,
+    opacity: cfg.opacity,
+    mixBlendMode: cfg.blend ?? "plus-lighter",
+    imageRendering: "auto",
+  }
+}
+
+// Easing — gentle start + soft settle so entrances don't feel linear.
+export const easeInOutCubic = (t: number) =>
+  t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2
+export const easeOutCubic = (t: number) => 1 - (1 - t) ** 3
+export const clamp01 = (t: number) => (t < 0 ? 0 : t > 1 ? 1 : t)
+
+/** Whether the OS asks for reduced motion (snap + steady stars). */
+export function prefersReducedMotion() {
+  return (
+    window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false
+  )
+}

--- a/frontend/src/components/dither/dither.css
+++ b/frontend/src/components/dither/dither.css
@@ -1,0 +1,60 @@
+/* Gruvbox-scoped replacements for the Tailwind utilities used by the vendored
+ * dither-kit components (upstream expects Tailwind + shadcn tokens; this app
+ * has neither). Every rule is scoped under .dither-root, which the chart root
+ * components add to their containers — nothing leaks into app CSS. */
+
+.dither-root { position: relative; height: 100%; width: 100%; }
+
+/* layout */
+.dither-root .absolute { position: absolute; }
+.dither-root .relative { position: relative; }
+.dither-root .inset-0 { inset: 0; }
+.dither-root .inset-x-0 { left: 0; right: 0; }
+.dither-root .top-0 { top: 0; }
+.dither-root .z-10 { z-index: 10; }
+.dither-root .flex { display: flex; }
+.dither-root .flex-col { flex-direction: column; }
+.dither-root .flex-wrap { flex-wrap: wrap; }
+.dither-root .items-center { align-items: center; }
+.dither-root .justify-center { justify-content: center; }
+.dither-root .justify-end { justify-content: flex-end; }
+.dither-root .justify-start { justify-content: flex-start; }
+.dither-root .gap-0\.5 { gap: 0.125rem; }
+.dither-root .gap-1\.5 { gap: 0.375rem; }
+.dither-root .gap-3 { gap: 0.75rem; }
+.dither-root .px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.dither-root .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.dither-root .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.dither-root .pl-2 { padding-left: 0.5rem; }
+.dither-root .mb-0\.5 { margin-bottom: 0.125rem; }
+.dither-root .ml-auto { margin-left: auto; }
+.dither-root .h-full { height: 100%; }
+.dither-root .w-full { width: 100%; }
+.dither-root .size-2 { width: 0.5rem; height: 0.5rem; }
+.dither-root .overflow-visible { overflow: visible; }
+.dither-root .rounded-md { border-radius: 6px; }
+.dither-root .rounded-\[1px\] { border-radius: 1px; }
+.dither-root .pointer-events-none { pointer-events: none; }
+.dither-root .pointer-events-auto { pointer-events: auto; }
+.dither-root .cursor-pointer { cursor: pointer; }
+.dither-root .opacity-40 { opacity: 0.4; }
+.dither-root .transition-opacity { transition: opacity 0.15s ease; }
+.dither-root .shadow-sm { box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3); }
+.dither-root .backdrop-blur-sm { backdrop-filter: blur(4px); }
+
+/* typography */
+.dither-root .font-mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.dither-root .text-\[10px\] { font-size: 10px; }
+.dither-root .text-\[11px\] { font-size: 11px; }
+.dither-root .tabular-nums { font-variant-numeric: tabular-nums; }
+.dither-root .fill-current { fill: currentColor; }
+
+/* gruvbox stand-ins for the shadcn theme tokens */
+.dither-root .text-muted-foreground { color: #a89984; }
+.dither-root .text-foreground { color: #ebdbb2; }
+.dither-root .text-popover-foreground { color: #ebdbb2; }
+.dither-root .hover\:text-foreground:hover { color: #ebdbb2; }
+.dither-root .bg-popover { background-color: #3c3836; }
+.dither-root .bg-popover\/70 { background-color: rgba(60, 56, 54, 0.7); }
+.dither-root .border { border: 1px solid #504945; }
+.dither-root .stroke-border { stroke: #504945; }

--- a/frontend/src/components/dither/dot.tsx
+++ b/frontend/src/components/dither/dot.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import { useChart } from "./chart-context"
+import { rgb, type Seed } from "./palette"
+import { useSeries } from "./series-context"
+
+export type DotVariant = "border" | "colored-border" | "filled"
+
+function dotPaint(variant: DotVariant, seed: Seed) {
+  switch (variant) {
+    case "colored-border":
+      return {
+        fill: "var(--card, #0b0b0c)",
+        stroke: rgb(seed.line),
+        strokeWidth: 1.5,
+      }
+    case "filled":
+      return { fill: rgb(seed.star), stroke: rgb(seed.line), strokeWidth: 1 }
+    default:
+      return {
+        fill: "var(--card, #0b0b0c)",
+        stroke: rgb(seed.star, 0.8),
+        strokeWidth: 1,
+      }
+  }
+}
+
+/** A marker at every data point along the series' top line. */
+export function Dot({
+  variant = "border",
+  r = 2,
+}: {
+  variant?: DotVariant
+  r?: number
+}) {
+  const ctx = useChart()
+  const { dataKey, seed } = useSeries("Dot")
+  const band = ctx.bands[dataKey]
+  if (!ctx.ready || !band) return null
+  const paint = dotPaint(variant, seed)
+
+  return (
+    // Fade in once the fill has drawn so dots don't float over the entrance.
+    <g
+      style={{
+        opacity: ctx.entranceDone ? 1 : 0,
+        transition: "opacity 300ms ease",
+      }}
+    >
+      {band.map((b, i) => (
+        <circle
+          {...paint}
+          // biome-ignore lint/suspicious/noArrayIndexKey: index is the stable x position
+          key={i}
+          cx={ctx.xCenter(i) ?? 0}
+          cy={ctx.y(b[1])}
+          r={r}
+        />
+      ))}
+    </g>
+  )
+}
+
+/** A single marker at the hovered point — keys off the shared hover index. */
+export function ActiveDot({
+  variant = "colored-border",
+  r = 3,
+}: {
+  variant?: DotVariant
+  r?: number
+}) {
+  const ctx = useChart()
+  const { dataKey, seed } = useSeries("ActiveDot")
+  const band = ctx.bands[dataKey]
+  if (!ctx.ready || !band || ctx.hoverIndex == null || !ctx.entranceDone)
+    return null
+  const b = band[ctx.hoverIndex]
+  if (!b) return null
+  const paint = dotPaint(variant, seed)
+  const cx = ctx.xCenter(ctx.hoverIndex)
+  const cy = ctx.y(b[1])
+
+  return (
+    <g>
+      {/* Soft halo so the active point is unmistakable over the dither. */}
+      <circle cx={cx} cy={cy} r={r + 3} fill={rgb(seed.line, 1, 0.18)} />
+      <circle cx={cx} cy={cy} r={r} {...paint} strokeWidth={2} />
+    </g>
+  )
+}

--- a/frontend/src/components/dither/grid.tsx
+++ b/frontend/src/components/dither/grid.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { useChartPart } from "./chart-context"
+
+export function Grid({
+  horizontal = true,
+  vertical = false,
+  strokeDasharray = "3 3",
+}: {
+  horizontal?: boolean
+  vertical?: boolean
+  strokeDasharray?: string
+}) {
+  const ctx = useChartPart("Grid")
+  if (!ctx.ready) return null
+  const { width } = ctx.plot
+
+  return (
+    <g className="stroke-border" strokeDasharray={strokeDasharray}>
+      {horizontal &&
+        ctx.y
+          .ticks(4)
+          .map((t) => (
+            <line
+              key={`h-${t}`}
+              x1={0}
+              x2={width}
+              y1={ctx.y(t)}
+              y2={ctx.y(t)}
+            />
+          ))}
+      {vertical &&
+        ctx.data.map((_, i) => (
+          <line
+            // biome-ignore lint/suspicious/noArrayIndexKey: index is the stable x position
+            key={`v-${i}`}
+            x1={ctx.xCenter(i) ?? 0}
+            x2={ctx.xCenter(i) ?? 0}
+            y1={0}
+            y2={ctx.plot.height}
+          />
+        ))}
+    </g>
+  )
+}
+
+// Render beneath the dither canvas so grid lines sit behind the fill.
+Grid.chartLayer = "back" as const

--- a/frontend/src/components/dither/index.ts
+++ b/frontend/src/components/dither/index.ts
@@ -1,0 +1,39 @@
+// Vendored from https://github.com/Boring-Software-Inc/dither-kit (MIT),
+// upstream commit 9fb0b14. Local changes: Tailwind utilities replaced by the
+// scoped dither.css (Gruvbox values), cn() drops tailwind-merge, palette
+// retuned to Gruvbox, and the standalone avatar/button/gradient components
+// are not vendored. Aesthetic credit: Evil Charts (evilcharts.com).
+export { Area, type AreaProps, Line, type SeriesProps } from "./area"
+export { AreaChart, type AreaChartProps, LineChart } from "./area-chart"
+export { Bar, type BarProps } from "./bar"
+export { BarChart } from "./bar-chart"
+export type { CartesianChartProps } from "./cartesian-root"
+export type {
+  AreaVariant,
+  ChartConfig,
+  ChartType,
+  Margins,
+  SeriesKind,
+  StrokeVariant,
+} from "./chart-context"
+export type {
+  BloomBlend,
+  BloomConfig,
+  BloomInput,
+  BloomLevel,
+} from "./dither-paint"
+export { ActiveDot, Dot, type DotVariant } from "./dot"
+export { Grid } from "./grid"
+export { Legend } from "./legend"
+export type { DitherColor } from "./palette"
+export type { PixelBloom, PixelColor } from "./pixel"
+export { Pie, type PieProps } from "./pie"
+export { PieChart, type PieChartProps } from "./pie-chart"
+export { Radar, type RadarProps } from "./radar"
+export { RadarChart, type RadarChartProps } from "./radar-chart"
+export type { StackType } from "./scales"
+export { Sparkline, type SparklineProps } from "./sparkline"
+export { Tooltip, type TooltipVariant } from "./tooltip"
+export { XAxis } from "./x-axis"
+export { YAxis } from "./y-axis"
+export { DitherHeatmap, type DitherHeatmapCell, type DitherHeatmapProps } from "./dither-heatmap"

--- a/frontend/src/components/dither/legend.tsx
+++ b/frontend/src/components/dither/legend.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { useCommonChart } from "./common-context"
+import { cn } from "./lib"
+import { rgb } from "./palette"
+
+/** Series/slice legend. With `isClickable`, each entry toggles its selection.
+ * Works in every chart family via the shared common context. */
+export function Legend({
+  isClickable = false,
+  align = "right",
+}: {
+  isClickable?: boolean
+  align?: "left" | "center" | "right"
+}) {
+  const chart = useCommonChart()
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-none absolute inset-x-0 top-0 flex flex-wrap gap-3 px-1",
+        align === "right" && "justify-end",
+        align === "center" && "justify-center",
+        align === "left" && "justify-start"
+      )}
+    >
+      {chart.names.map((name) => {
+        const seed = chart.seedOf(name)
+        const emphasis = chart.selectedDataKey ?? chart.focusDataKey
+        const dimmed = emphasis !== null && emphasis !== name
+        return (
+          <button
+            key={name}
+            type="button"
+            disabled={!isClickable}
+            onClick={() =>
+              chart.selectDataKey(chart.selectedDataKey === name ? null : name)
+            }
+            // Hovering an entry spotlights its series so overlapping layers
+            // (e.g. two meshed radar polygons) can be told apart at a glance.
+            onPointerEnter={() => chart.setFocusDataKey(name)}
+            onPointerLeave={() => chart.setFocusDataKey(null)}
+            onFocus={() => chart.setFocusDataKey(name)}
+            onBlur={() => chart.setFocusDataKey(null)}
+            className={cn(
+              "flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground transition-opacity",
+              isClickable &&
+                "pointer-events-auto cursor-pointer hover:text-foreground",
+              dimmed && "opacity-40"
+            )}
+          >
+            <span
+              className="size-2 rounded-[1px]"
+              style={{ backgroundColor: rgb(seed.fill) }}
+            />
+            {chart.labelOf(name)}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+Legend.chartLayer = "dom" as const

--- a/frontend/src/components/dither/lib.ts
+++ b/frontend/src/components/dither/lib.ts
@@ -1,0 +1,8 @@
+import { type ClassValue, clsx } from "clsx"
+
+/** className combiner — vendored change: upstream wraps clsx in tailwind-merge,
+ * but this app has no Tailwind (utilities live in dither.css), so plain clsx
+ * is sufficient. */
+export function cn(...inputs: ClassValue[]) {
+  return clsx(inputs)
+}

--- a/frontend/src/components/dither/palette.ts
+++ b/frontend/src/components/dither/palette.ts
@@ -1,0 +1,42 @@
+// Shared seed palette for the dither chart family. Mirrors the seeds in
+// `dither-chart.tsx` so a series rendered through the composable engine reads
+// with the exact same fill / line / star hues as the legacy sparkline.
+
+export type Rgb = [number, number, number]
+
+export type DitherColor =
+  | "green"
+  | "blue"
+  | "purple"
+  | "pink"
+  | "orange"
+  | "red"
+  | "yellow"
+  | "aqua"
+  | "grey"
+
+export type Seed = { fill: Rgb; line: Rgb; star: Rgb }
+
+// Each seed: the area-fill hue, the bright series line, and the star sparkle.
+export const PALETTE: Record<DitherColor, Seed> = {
+  // Gruvbox retune (vendored change): fills sit on the gruvbox accents so
+  // every chart reads in-theme; line/star are progressively brighter tints.
+  green: { fill: [184, 187, 38], line: [215, 219, 90], star: [235, 238, 150] },
+  blue: { fill: [131, 165, 152], line: [170, 200, 190], star: [208, 226, 220] },
+  purple: { fill: [177, 98, 134], line: [211, 134, 155], star: [232, 180, 200] },
+  pink: { fill: [211, 134, 155], line: [235, 175, 195], star: [246, 210, 226] },
+  orange: { fill: [254, 128, 25], line: [255, 178, 100], star: [255, 214, 165] },
+  red: { fill: [251, 73, 52], line: [255, 140, 120], star: [255, 192, 178] },
+  yellow: { fill: [250, 189, 47], line: [255, 215, 110], star: [255, 236, 175] },
+  aqua: { fill: [142, 192, 124], line: [180, 220, 162], star: [216, 240, 202] },
+  // No-data: muted gruvbox gray so empty metrics read as "nothing here".
+  grey: { fill: [146, 131, 116], line: [175, 162, 144], star: [205, 196, 180] },
+}
+
+export const rgb = ([r, g, b]: Rgb, k = 1, a = 1) =>
+  `rgba(${Math.round(r * k)},${Math.round(g * k)},${Math.round(b * k)},${a})`
+
+export const seedOfColor = (color: DitherColor): Seed => PALETTE[color]
+
+export const isDitherColor = (value: unknown): value is DitherColor =>
+  typeof value === "string" && value in PALETTE

--- a/frontend/src/components/dither/pie-canvas.tsx
+++ b/frontend/src/components/dither/pie-canvas.tsx
@@ -1,0 +1,223 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import {
+  BAYER,
+  backingSize,
+  bloomLayerStyle,
+  easeInOutCubic,
+  OFF_TIER,
+  prefersReducedMotion,
+} from "./dither-paint"
+import { rgb } from "./palette"
+import { sliceAtAngle } from "./polar"
+import { usePolarChart } from "./polar-context"
+
+const TOP = -Math.PI / 2
+const TAU = Math.PI * 2
+const POP = 6 // px the hovered slice bulges outward
+
+/**
+ * Dither canvas for pie / donut charts. Each backing pixel is mapped back to
+ * plot space, tested for its slice by angle, and filled with the ordered-dither
+ * scatter — dense at the outer edge, thinning toward the centre — capped by a
+ * bright arc on the rim. The pie sweeps in clockwise on mount; the hovered slice
+ * bulges outward with a brighter rim while the rest dim.
+ */
+export function PieCanvas() {
+  const ctx = usePolarChart()
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const bloomRef = useRef<HTMLCanvasElement>(null)
+
+  const { width, height } = ctx.plot
+  const { cols, rows } = backingSize(width, height)
+
+  // The RAF loop reads the latest ctx through a ref; written in an effect
+  // (never during render) — mutating a ref mid-render tears under Strict Mode /
+  // concurrent rendering.
+  const state = useRef(ctx)
+  useEffect(() => {
+    state.current = ctx
+  })
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    const c = canvas?.getContext("2d")
+    if (!(canvas && c) || cols <= 0 || rows <= 0) return
+    canvas.width = cols
+    canvas.height = rows
+
+    const bloomCanvas = bloomRef.current
+    const bloomCtx = bloomCanvas?.getContext("2d") ?? null
+    if (bloomCanvas) {
+      bloomCanvas.width = cols
+      bloomCanvas.height = rows
+    }
+
+    const reduce = prefersReducedMotion()
+    const animate = state.current.animate && !reduce
+    const duration = state.current.animationDuration
+    let raf = 0
+    let animStart = 0
+    let lastProg = -1
+    let lastRevision = state.current.revision
+    let intensity = 0
+    let popEase = 0 // eases the hovered slice's outward bulge
+    let needsFill = true
+    let lastPaintSig = ""
+    let lastSelected: string | null | undefined = Symbol() as never
+    let lastHover: number | null | undefined = Symbol() as never
+
+    const paint = (prog: number) => {
+      const s = state.current
+      const slices = s.pie
+      if (!slices) return
+      c.clearRect(0, 0, cols, rows)
+      const cx = s.center.x
+      const cy = s.center.y
+      const outerR = s.outerRadius
+      const innerR = s.innerRadius
+      const revealAngle = TOP + easeInOutCubic(prog) * TAU
+
+      for (let y = 0; y < rows; y++) {
+        const py = ((y + 0.5) * height) / rows
+        for (let x = 0; x < cols; x++) {
+          const px = ((x + 0.5) * width) / cols
+          const dx = px - cx
+          const dy = py - cy
+          const r = Math.hypot(dx, dy)
+          if (r < innerR) continue
+          const angle = Math.atan2(dy, dx)
+          let na = angle
+          while (na < TOP) na += TAU
+          while (na >= TOP + TAU) na -= TAU
+          if (na > revealAngle) continue // clockwise sweep-in
+          const si = sliceAtAngle(slices, angle)
+          if (si < 0) continue
+          const slice = slices[si]
+          const active = s.hoverIndex === si
+          const localOuter = active ? outerR + POP * popEase : outerR
+          if (r > localOuter) continue
+
+          const seed = s.seedOf(slice.name)
+          const variant = s.variantOf(slice.name)
+          const emphasis = s.selectedDataKey ?? s.focusDataKey
+          const selDim = emphasis !== null && emphasis !== slice.name ? 0.3 : 1
+          const it = intensity + (active ? 0.4 * popEase : 0)
+
+          // Bright rim on the outer edge — thicker on the hovered slice.
+          if (localOuter - r < (active ? 1.4 + popEase : 1.4)) {
+            c.fillStyle = rgb(seed.fill, 1, selDim)
+            c.fillRect(x, y, 1, 1)
+            continue
+          }
+          const density = (r - innerR) / Math.max(localOuter - innerR, 1)
+          const bias = variant === "dotted" ? 0.12 : 0
+          if (variant === "hatched" && ((x + y) & 3) >= 2) continue
+          const lit =
+            variant === "solid" ||
+            density > BAYER[y & 3][x & 3] - 0.1 * it - bias
+          if (variant === "dotted" && !lit) continue
+          // Density → opacity (see the colour-vs-opacity note in dither-paint);
+          // off cells drop to a faint tier, never a hole to the background.
+          const k = (0.35 + density * 0.65) * (1 + 0.22 * it)
+          const alpha = Math.min(1, (lit ? k : k * OFF_TIER) * selDim)
+          c.fillStyle = rgb(seed.fill, 1, alpha)
+          c.fillRect(x, y, 1, 1)
+        }
+      }
+    }
+
+    const draw = (now: number) => {
+      raf = requestAnimationFrame(draw)
+      const s = state.current
+      if (!s.ready || !s.pie) return
+      if (bloomCtx) {
+        const on = s.bloom !== "off" && (!s.bloomOnHover || s.isMouseInChart)
+        if (on) {
+          bloomCtx.clearRect(0, 0, cols, rows)
+          bloomCtx.drawImage(canvas, 0, 0)
+        }
+      }
+      if (s.revision !== lastRevision) {
+        lastRevision = s.revision
+        animStart = 0
+        lastProg = -1
+      }
+      if (!animStart) animStart = now
+      const prog = animate ? Math.min(1, (now - animStart) / duration) : 1
+
+      const emphasisNow = s.selectedDataKey ?? s.focusDataKey
+      if (emphasisNow !== lastSelected) {
+        lastSelected = emphasisNow
+        needsFill = true
+      }
+      if (s.hoverIndex !== lastHover) {
+        lastHover = s.hoverIndex
+        popEase = 0 // a freshly-hovered slice bulges out from rest
+        needsFill = true
+      }
+      const itTarget = s.isMouseInChart ? 1 : 0
+      if (Math.abs(intensity - itTarget) > 0.001) {
+        intensity += (itTarget - intensity) * (reduce ? 1 : 0.16)
+        needsFill = true
+      } else intensity = itTarget
+      // Ease the hovered slice's bulge in (and back out when nothing's hovered).
+      const popTarget = s.hoverIndex != null ? 1 : 0
+      if (Math.abs(popEase - popTarget) > 0.001) {
+        popEase += (popTarget - popEase) * (reduce ? 1 : 0.22)
+        needsFill = true
+      } else popEase = popTarget
+      if (prog !== lastProg) {
+        lastProg = prog
+        needsFill = true
+      }
+
+      // Live tweak repaint (variant, donut inner radius) without re-sweeping.
+      const paintSig = `${s.innerRadius}|${s.pie
+        .map((sl) => s.variantOf(sl.name))
+        .join(",")}`
+      if (paintSig !== lastPaintSig) {
+        lastPaintSig = paintSig
+        needsFill = true
+      }
+
+      if (!needsFill) return
+      paint(prog)
+      needsFill = false
+    }
+
+    raf = requestAnimationFrame(draw)
+    return () => cancelAnimationFrame(raf)
+  }, [cols, rows, width, height])
+
+  const bloom = bloomLayerStyle(
+    ctx.bloom,
+    ctx.bloomOnHover ? ctx.isMouseInChart : true
+  )
+  const pos = {
+    left: ctx.margins.left,
+    top: ctx.margins.top,
+    width,
+    height,
+  } as const
+
+  return (
+    <>
+      <canvas
+        ref={canvasRef}
+        className="pointer-events-none absolute"
+        style={{ ...pos, imageRendering: "pixelated" }}
+      />
+      <canvas
+        ref={bloomRef}
+        className="pointer-events-none absolute"
+        style={{
+          ...pos,
+          transition: "opacity 220ms ease",
+          ...(bloom ?? { opacity: 0 }),
+        }}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/dither/pie-chart.tsx
+++ b/frontend/src/components/dither/pie-chart.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import type { ReactNode } from "react"
+import type { ChartConfig, Margins } from "./chart-context"
+import type { BloomInput } from "./dither-paint"
+import { PieCanvas } from "./pie-canvas"
+import { PolarRoot } from "./polar-root"
+
+// `object` rather than `Record<string, unknown>`: interfaces don't get an
+// implicit index signature, so interface-typed rows failed to satisfy the
+// generic. Internal layers still index rows through their own Row type.
+type Row = object
+
+export type PieChartProps<TData extends Row> = {
+  data: TData[]
+  config: ChartConfig
+  children: ReactNode
+  dataKey: string // value field
+  nameKey: string // slice-name field (looked up in config for colour)
+  innerRadius?: number // 0–1 ratio for a donut
+  margins?: Partial<Margins>
+  className?: string
+  animate?: boolean
+  animationDuration?: number
+  replayToken?: number
+  bloom?: BloomInput
+  bloomOnHover?: boolean
+  defaultSelectedDataKey?: string | null
+  onSelectionChange?: (key: string | null) => void
+}
+
+/** Composable dither **pie / donut** chart. Compose `<Pie>`, `<Legend>`, … inside. */
+export function PieChart<TData extends Row>(props: PieChartProps<TData>) {
+  return <PolarRoot chartType="pie" Canvas={PieCanvas} {...props} />
+}

--- a/frontend/src/components/dither/pie.tsx
+++ b/frontend/src/components/dither/pie.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { useEffect } from "react"
+import type { AreaVariant } from "./chart-context"
+import { usePolarPart } from "./polar-context"
+
+export type PieProps = {
+  /** Fill texture applied to every slice. */
+  variant?: AreaVariant
+}
+
+/**
+ * The pie/donut ring. Slices come from the chart `data` (one per row); this part
+ * sets the shared fill variant. The dithered wedges are painted on the canvas.
+ */
+export function Pie({ variant = "gradient" }: PieProps) {
+  const ctx = usePolarPart("Pie", "pie")
+  const { registerVariant, unregisterVariant } = ctx
+
+  useEffect(() => {
+    registerVariant("*", variant)
+    return () => unregisterVariant("*")
+  }, [variant, registerVariant, unregisterVariant])
+
+  return null
+}

--- a/frontend/src/components/dither/pixel.ts
+++ b/frontend/src/components/dither/pixel.ts
@@ -1,0 +1,114 @@
+// Standalone pixel primitives for the non-chart Dither Kit pieces (avatar,
+// gradient). Deliberately free of the chart engine so those items install
+// without `core` — only palette.ts is shared. The Bayer matrix and bloom
+// presets mirror dither-paint.ts so everything reads as one texture.
+
+import { type DitherColor, PALETTE, type Rgb } from "./palette"
+
+// 4×4 ordered (Bayer) matrix, normalized to 0–1 thresholds — the same matrix
+// the charts dither with.
+export const BAYER4 = [
+  [0, 8, 2, 10],
+  [12, 4, 14, 6],
+  [3, 11, 1, 9],
+  [15, 7, 13, 5],
+].map((row) => row.map((v) => (v + 0.5) / 16))
+
+export const clamp01 = (t: number) => (t < 0 ? 0 : t > 1 ? 1 : t)
+
+/** 32-bit FNV-1a hash — turns any string seed into a stable uint32. */
+export function fnv1a(str: string): number {
+  let h = 0x811c9dc5
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return h >>> 0
+}
+
+/** Tiny deterministic PRNG (xorshift32) — returns floats in [0, 1). */
+export function xorshift32(seed: number): () => number {
+  let s = seed || 0x9e3779b9
+  return () => {
+    s ^= s << 13
+    s >>>= 0
+    s ^= s >>> 17
+    s ^= s << 5
+    s >>>= 0
+    return s / 0x100000000
+  }
+}
+
+/** A named palette colour or a raw hue (0–360). */
+export type PixelColor = DitherColor | number
+
+/** Hue (0–360) → an rgb fill tuned to sit alongside the chart palette. */
+export function hueFill(hue: number): Rgb {
+  const h = ((hue % 360) + 360) % 360
+  const s = 0.85
+  const l = 0.58
+  const c = (1 - Math.abs(2 * l - 1)) * s
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1))
+  const m = l - c / 2
+  const [r, g, b] =
+    h < 60
+      ? [c, x, 0]
+      : h < 120
+        ? [x, c, 0]
+        : h < 180
+          ? [0, c, x]
+          : h < 240
+            ? [0, x, c]
+            : h < 300
+              ? [x, 0, c]
+              : [c, 0, x]
+  return [
+    Math.round((r + m) * 255),
+    Math.round((g + m) * 255),
+    Math.round((b + m) * 255),
+  ]
+}
+
+/** Resolve a {@link PixelColor} to its rgb fill. */
+export function fillOf(color: PixelColor): Rgb {
+  return typeof color === "number" ? hueFill(color) : PALETTE[color].fill
+}
+
+// Bloom — same recipe as the charts: a blurred copy of the crisp canvas,
+// composited additively so the glow stays in the dither's own colour.
+export type PixelBloom = "off" | "low" | "high" | "aura"
+
+const BLOOM_PRESET: Record<
+  Exclude<PixelBloom, "off">,
+  { blur: number; brightness: number; opacity: number; saturate: number }
+> = {
+  low: { blur: 3, brightness: 1.35, opacity: 0.7, saturate: 1.4 },
+  high: { blur: 5, brightness: 1.5, opacity: 0.78, saturate: 1.5 },
+  aura: { blur: 15, brightness: 2.9, opacity: 0.1, saturate: 3 },
+}
+
+export type PixelBloomStyle = {
+  filter: string
+  opacity: number
+  mixBlendMode: "plus-lighter"
+  imageRendering: "auto"
+}
+
+/** Style for the bloom layer canvas. null when off. */
+export function pixelBloomStyle(bloom: PixelBloom): PixelBloomStyle | null {
+  if (bloom === "off") return null
+  const cfg = BLOOM_PRESET[bloom]
+  return {
+    filter: `blur(${cfg.blur}px) brightness(${cfg.brightness}) saturate(${cfg.saturate})`,
+    opacity: cfg.opacity,
+    mixBlendMode: "plus-lighter",
+    imageRendering: "auto",
+  }
+}
+
+/** Whether the OS asks for reduced motion (skip entrances). */
+export function pixelPrefersReducedMotion(): boolean {
+  return (
+    window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false
+  )
+}

--- a/frontend/src/components/dither/polar-context.tsx
+++ b/frontend/src/components/dither/polar-context.tsx
@@ -1,0 +1,382 @@
+"use client"
+
+import { createContext, use, useCallback, useMemo, useState } from "react"
+import {
+  type AreaVariant,
+  type ChartConfig,
+  type ChartType,
+  type Margins,
+  useRevision,
+} from "./chart-context"
+import type { CommonChart } from "./common-context"
+import type { BloomInput } from "./dither-paint"
+import type { Seed } from "./palette"
+import { seedOfColor } from "./palette"
+import { type PieSlice, pieSlices, type RadarAxis, radarAxes } from "./polar"
+import type { Dimensions } from "./use-chart-dimensions"
+
+type Row = Record<string, unknown>
+
+const ROOT_OF: Record<string, string> = {
+  pie: "<PieChart />",
+  radar: "<RadarChart />",
+}
+
+export type PolarChartContextValue = {
+  chartType: ChartType
+  config: ChartConfig
+  configKeys: string[]
+  data: Row[]
+  dataLength: number
+  ready: boolean
+  plot: { width: number; height: number }
+  margins: Margins
+  center: { x: number; y: number }
+  outerRadius: number
+  innerRadius: number
+  animate: boolean
+  animationDuration: number
+  revision: number
+  bloom: BloomInput
+  bloomOnHover: boolean
+
+  seedOf: (key: string) => Seed
+  variantOf: (key: string) => AreaVariant
+  registerVariant: (key: string, variant: AreaVariant) => void
+  unregisterVariant: (key: string) => void
+
+  selectedDataKey: string | null
+  selectDataKey: (key: string | null) => void
+  /** Legend-hover spotlight — dims every series but this one while set. */
+  focusDataKey: string | null
+  setFocusDataKey: (key: string | null) => void
+  hoverIndex: number | null
+  setHoverIndex: (i: number | null) => void
+  setCursor: (px: number, py: number) => void
+  isMouseInChart: boolean
+  setMouseInChart: (over: boolean) => void
+
+  pie: PieSlice[] | null // present for pie charts
+  radar: { axes: RadarAxis[]; max: number } | null // present for radar charts
+
+  common: CommonChart
+}
+
+const PolarChartContext = createContext<PolarChartContextValue | null>(null)
+
+export function usePolarChart() {
+  const ctx = use(PolarChartContext)
+  if (!ctx) {
+    throw new Error("Polar chart parts must be used within a polar chart root.")
+  }
+  return ctx
+}
+
+/** Boundary guard for polar parts (`<Pie>`, `<Radar>`). */
+export function usePolarPart(part: string, kind: "pie" | "radar") {
+  const ctx = use(PolarChartContext)
+  if (!ctx) {
+    throw new Error(`<${part} /> must be used within ${ROOT_OF[kind]}.`)
+  }
+  if (ctx.chartType !== kind) {
+    throw new Error(
+      `<${part} /> is not valid inside ${ROOT_OF[ctx.chartType]} — it belongs in ${ROOT_OF[kind]}.`
+    )
+  }
+  return ctx
+}
+
+export { PolarChartContext }
+
+export function usePolarController({
+  chartType,
+  data,
+  config,
+  dataKey,
+  nameKey,
+  innerRadiusRatio,
+  dimensions,
+  margins,
+  animate = true,
+  animationDuration = 900,
+  replayToken = 0,
+  bloom = "off",
+  bloomOnHover = false,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+}: {
+  chartType: "pie" | "radar"
+  data: Row[]
+  config: ChartConfig
+  dataKey: string
+  nameKey: string
+  innerRadiusRatio: number
+  dimensions: Dimensions
+  margins: Margins
+  animate?: boolean
+  animationDuration?: number
+  replayToken?: number
+  bloom?: BloomInput
+  bloomOnHover?: boolean
+  defaultSelectedDataKey?: string | null
+  onSelectionChange?: (key: string | null) => void
+}): PolarChartContextValue {
+  // This object becomes the PolarChartContext value, so its identity — and the
+  // identity of every function/object it carries — must stay stable across
+  // renders that don't change the inputs; otherwise every consumer (legend,
+  // tooltip, slices, axes) re-renders on every parent render. The expensive
+  // derivations, exposed callbacks, and returned value are memoized below;
+  // cheap scalars (radii, ready) are left bare as plain recomputed reads.
+
+  // Memoized: drives `pie`/`radar`/`common` — a fresh array would bust them.
+  const configKeys = useMemo(() => Object.keys(config), [config])
+  const revision = useRevision(data, replayToken)
+
+  const [selectedDataKey, setSelectedDataKey] = useState<string | null>(
+    defaultSelectedDataKey
+  )
+  const [focusDataKey, setFocusDataKey] = useState<string | null>(null)
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null)
+  const [cursorX, setCursorX] = useState(0)
+  const [cursorY, setCursorY] = useState(0)
+  const [isMouseInChart, setMouseInChart] = useState(false)
+  // Stable (only wraps two useState setters) so the value keeps its identity.
+  const setCursor = useCallback((px: number, py: number) => {
+    setCursorX(px)
+    setCursorY(py)
+  }, [])
+  const [variants, setVariants] = useState<Record<string, AreaVariant>>({})
+
+  // useCallback for the same reason as registerSeries in chart-context.tsx:
+  // pie.tsx/radar.tsx list these as effect deps, so without stable identities
+  // the unregister/register effect re-fires and its setState pair loops.
+  const registerVariant = useCallback((key: string, variant: AreaVariant) => {
+    setVariants((prev) =>
+      prev[key] === variant ? prev : { ...prev, [key]: variant }
+    )
+  }, [])
+  const unregisterVariant = useCallback((key: string) => {
+    setVariants((prev) => {
+      if (!(key in prev)) return prev
+      const next = { ...prev }
+      delete next[key]
+      return next
+    })
+  }, [])
+
+  // Stable so the value keeps its identity; re-created only on config change.
+  const selectDataKey = useCallback(
+    (key: string | null) => {
+      setSelectedDataKey(key)
+      onSelectionChange?.(key)
+    },
+    [onSelectionChange]
+  )
+
+  // The root spreads margins fresh every render; pin a stable object off the
+  // four numbers so it doesn't, on its own, invalidate the value.
+  const { top: mTop, right: mRight, bottom: mBottom, left: mLeft } = margins
+  const stableMargins = useMemo(
+    () => ({ top: mTop, right: mRight, bottom: mBottom, left: mLeft }),
+    [mTop, mRight, mBottom, mLeft]
+  )
+
+  const plotWidth = Math.max(0, dimensions.width - mLeft - mRight)
+  const plotHeight = Math.max(0, dimensions.height - mTop - mBottom)
+  const ready = plotWidth > 0 && plotHeight > 0
+  const pad = chartType === "radar" ? 20 : 6
+  const outerRadius = Math.max(0, Math.min(plotWidth, plotHeight) / 2 - pad)
+  const innerRadius = chartType === "pie" ? outerRadius * innerRadiusRatio : 0
+  const centerX = plotWidth / 2
+  const centerY = plotHeight / 2
+
+  // Stable so `common` and the value stay stable; re-created only on config.
+  const seedOf = useCallback(
+    (key: string) => seedOfColor(config[key]?.color ?? "grey"),
+    [config]
+  )
+  // "*" is the pie-wide variant set by <Pie>; radar registers per series key.
+  const variantOf = useCallback(
+    (key: string) => variants[key] ?? variants["*"] ?? "gradient",
+    [variants]
+  )
+
+  // Memoized: slice geometry — recomputing it on every hover/cursor tick would
+  // rebuild the pie layout needlessly.
+  const pie = useMemo(
+    () => (chartType === "pie" ? pieSlices(data, dataKey, nameKey) : null),
+    [chartType, data, dataKey, nameKey]
+  )
+
+  // Memoized: walks every row × series for the axis max, then builds the axes.
+  const radar = useMemo(() => {
+    if (chartType !== "radar") return null
+    let max = 0
+    for (const row of data) {
+      for (const key of configKeys) {
+        const v = Number(row[key]) || 0
+        if (v > max) max = v
+      }
+    }
+    return { axes: radarAxes(data, nameKey), max: max || 1 }
+  }, [chartType, data, configKeys, nameKey])
+
+  // Memoized: this is the value handed to CommonChartContext (Legend/Tooltip),
+  // so it needs its own stable identity independent of the parent value.
+  const common: CommonChart = useMemo<CommonChart>(() => {
+    const tooltipLeft = Math.max(48, Math.min(plotWidth + mLeft - 48, cursorX))
+    const tooltipTop = Math.max(mTop + 44, cursorY)
+    const emphasis = selectedDataKey ?? focusDataKey
+    if (chartType === "pie" && pie) {
+      const names = pie.map((s) => s.name)
+      return {
+        names,
+        tooltipTop,
+        labelOf: (n) => config[n]?.label ?? n,
+        seedOf,
+        selectedDataKey,
+        selectDataKey,
+        focusDataKey,
+        setFocusDataKey,
+        hoverIndex,
+        ready,
+        tooltipLeft,
+        heading: (i) => pie[i]?.name ?? null,
+        itemsAt: (i) => {
+          const s = pie[i]
+          if (!s) return []
+          return [
+            {
+              name: s.name,
+              label: config[s.name]?.label ?? s.name,
+              value: s.value,
+              seed: seedOf(s.name),
+              dimmed: emphasis !== null && emphasis !== s.name,
+            },
+          ]
+        },
+      }
+    }
+    // radar
+    return {
+      names: configKeys,
+      tooltipTop,
+      labelOf: (n) => config[n]?.label ?? n,
+      seedOf,
+      selectedDataKey,
+      selectDataKey,
+      focusDataKey,
+      setFocusDataKey,
+      hoverIndex,
+      ready,
+      tooltipLeft,
+      heading: (i) => radar?.axes[i]?.label ?? null,
+      itemsAt: (i) =>
+        configKeys.map((name) => {
+          const raw = data[i]?.[name]
+          return {
+            name,
+            label: config[name]?.label ?? name,
+            value: typeof raw === "number" ? raw : 0,
+            seed: seedOf(name),
+            dimmed: emphasis !== null && emphasis !== name,
+          }
+        }),
+    }
+  }, [
+    chartType,
+    config,
+    configKeys,
+    data,
+    pie,
+    radar,
+    seedOf,
+    selectedDataKey,
+    selectDataKey,
+    focusDataKey,
+    setFocusDataKey,
+    hoverIndex,
+    ready,
+    plotWidth,
+    mLeft,
+    mTop,
+    cursorX,
+    cursorY,
+  ])
+
+  // Memoized: this is the PolarChartContext value. A fresh object here would
+  // re-render every consumer on every parent render — the reason the pieces
+  // above are stabilized. Rebuilds only when a listed input changes. The
+  // useState setters are listed but never change identity.
+  return useMemo<PolarChartContextValue>(
+    () => ({
+      chartType,
+      config,
+      configKeys,
+      data,
+      dataLength: data.length,
+      ready,
+      plot: { width: plotWidth, height: plotHeight },
+      margins: stableMargins,
+      center: { x: centerX, y: centerY },
+      outerRadius,
+      innerRadius,
+      animate,
+      animationDuration,
+      revision,
+      bloom,
+      bloomOnHover,
+      seedOf,
+      variantOf,
+      registerVariant,
+      unregisterVariant,
+      selectedDataKey,
+      selectDataKey,
+      focusDataKey,
+      setFocusDataKey,
+      hoverIndex,
+      setHoverIndex,
+      setCursor,
+      isMouseInChart,
+      setMouseInChart,
+      pie,
+      radar,
+      common,
+    }),
+    [
+      chartType,
+      config,
+      configKeys,
+      data,
+      ready,
+      plotWidth,
+      plotHeight,
+      stableMargins,
+      centerX,
+      centerY,
+      outerRadius,
+      innerRadius,
+      animate,
+      animationDuration,
+      revision,
+      bloom,
+      bloomOnHover,
+      seedOf,
+      variantOf,
+      registerVariant,
+      unregisterVariant,
+      selectedDataKey,
+      selectDataKey,
+      focusDataKey,
+      setFocusDataKey,
+      hoverIndex,
+      setHoverIndex,
+      setCursor,
+      isMouseInChart,
+      setMouseInChart,
+      pie,
+      radar,
+      common,
+    ]
+  )
+}

--- a/frontend/src/components/dither/polar-root.tsx
+++ b/frontend/src/components/dither/polar-root.tsx
@@ -1,0 +1,174 @@
+"use client"
+
+import {
+  Children,
+  type ComponentType,
+  isValidElement,
+  type ReactNode,
+} from "react"
+import type { ChartConfig, Margins } from "./chart-context"
+import { CommonChartContext } from "./common-context"
+import type { BloomInput } from "./dither-paint"
+import { cn } from "./lib"
+import "./dither.css"
+import { axisAtAngle, sliceAtAngle } from "./polar"
+import { PolarChartContext, usePolarController } from "./polar-context"
+import { useChartDimensions } from "./use-chart-dimensions"
+
+// `object` rather than `Record<string, unknown>`: interfaces don't get an
+// implicit index signature, so interface-typed rows failed to satisfy the
+// generic. Internal layers still index rows through their own Row type.
+type Row = object
+
+const DEFAULT_POLAR_MARGINS: Margins = {
+  top: 22,
+  right: 14,
+  bottom: 14,
+  left: 14,
+}
+
+function layerOf(node: ReactNode): "back" | "dom" | "svg" {
+  if (!isValidElement(node) || typeof node.type === "string") return "svg"
+  return (node.type as { chartLayer?: "back" | "dom" }).chartLayer ?? "svg"
+}
+
+export type PolarRootProps<TData extends Row> = {
+  chartType: "pie" | "radar"
+  /** Family painter — `PieCanvas` or `RadarCanvas`; ships with each chart. */
+  Canvas: ComponentType
+  /** Extra back-layer SVG content (e.g. the radar frame). */
+  backDecoration?: ReactNode
+  data: TData[]
+  config: ChartConfig
+  children: ReactNode
+  dataKey: string
+  nameKey: string
+  innerRadius?: number // 0–1 ratio (donut); pie only
+  margins?: Partial<Margins>
+  className?: string
+  animate?: boolean
+  animationDuration?: number
+  replayToken?: number
+  bloom?: BloomInput
+  bloomOnHover?: boolean
+  defaultSelectedDataKey?: string | null
+  onSelectionChange?: (key: string | null) => void
+}
+
+export function PolarRoot<TData extends Row>({
+  chartType,
+  Canvas,
+  backDecoration,
+  data,
+  config,
+  children,
+  dataKey,
+  nameKey,
+  innerRadius = 0,
+  margins: marginsProp,
+  className,
+  animate = true,
+  animationDuration = 900,
+  replayToken = 0,
+  bloom = "off",
+  bloomOnHover = false,
+  defaultSelectedDataKey = null,
+  onSelectionChange,
+}: PolarRootProps<TData>) {
+  const { ref, size } = useChartDimensions<HTMLDivElement>()
+  const margins = { ...DEFAULT_POLAR_MARGINS, ...marginsProp }
+
+  const ctx = usePolarController({
+    chartType,
+    // Safe: the controller only reads row[key] for the configured keys.
+    data: data as Record<string, unknown>[],
+    config,
+    dataKey,
+    nameKey,
+    innerRadiusRatio: innerRadius,
+    dimensions: size,
+    margins,
+    animate,
+    animationDuration,
+    replayToken,
+    bloom,
+    bloomOnHover,
+    defaultSelectedDataKey,
+    onSelectionChange,
+  })
+
+  const backChildren: ReactNode[] = []
+  const svgChildren: ReactNode[] = []
+  const domChildren: ReactNode[] = []
+  Children.forEach(children, (child) => {
+    const layer = layerOf(child)
+    if (layer === "back") backChildren.push(child)
+    else if (layer === "dom") domChildren.push(child)
+    else svgChildren.push(child)
+  })
+
+  const onMove = (clientX: number, clientY: number) => {
+    const el = ref.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    const dx = clientX - rect.left - margins.left - ctx.center.x
+    const dy = clientY - rect.top - margins.top - ctx.center.y
+    const angle = Math.atan2(dy, dx)
+    const r = Math.hypot(dx, dy)
+    if (chartType === "pie" && ctx.pie) {
+      const inside = r <= ctx.outerRadius && r >= ctx.innerRadius
+      const i = inside ? sliceAtAngle(ctx.pie, angle) : -1
+      ctx.setHoverIndex(i >= 0 ? i : null)
+    } else if (ctx.radar) {
+      ctx.setHoverIndex(axisAtAngle(ctx.radar.axes, angle))
+    }
+    ctx.setCursor(clientX - rect.left, clientY - rect.top)
+  }
+
+  return (
+    <PolarChartContext value={ctx}>
+      <CommonChartContext value={ctx.common}>
+        <div
+          ref={ref}
+          className={cn("dither-root relative h-full w-full", className)}
+          onPointerEnter={() => ctx.setMouseInChart(true)}
+          onPointerMove={(e) => onMove(e.clientX, e.clientY)}
+          onPointerLeave={() => {
+            ctx.setMouseInChart(false)
+            ctx.setHoverIndex(null)
+          }}
+        >
+          {ctx.ready && (
+            <svg
+              width={size.width}
+              height={size.height}
+              className="absolute inset-0 overflow-visible"
+              aria-hidden
+              role="presentation"
+            >
+              <g transform={`translate(${margins.left},${margins.top})`}>
+                {backDecoration}
+                {backChildren}
+              </g>
+            </svg>
+          )}
+          <Canvas />
+          {ctx.ready && (
+            <svg
+              width={size.width}
+              height={size.height}
+              className="absolute inset-0 overflow-visible"
+              role="img"
+              aria-label="Chart"
+            >
+              <g transform={`translate(${margins.left},${margins.top})`}>
+                {svgChildren}
+              </g>
+            </svg>
+          )}
+          {domChildren}
+        </div>
+      </CommonChartContext>
+    </PolarChartContext>
+  )
+}

--- a/frontend/src/components/dither/polar.ts
+++ b/frontend/src/components/dither/polar.ts
@@ -1,0 +1,125 @@
+// Polar geometry for pie + radar dither charts. Angles start at the top
+// (−90°) and run clockwise, matching how the slices/axes read on screen.
+
+type Row = Record<string, unknown>
+
+const TOP = -Math.PI / 2
+const TAU = Math.PI * 2
+
+export type PieSlice = {
+  name: string
+  value: number
+  start: number // radians
+  end: number
+  mid: number
+}
+
+/** Slice angles from each data row's value under `dataKey`, named by `nameKey`. */
+export function pieSlices(
+  data: Row[],
+  dataKey: string,
+  nameKey: string
+): PieSlice[] {
+  const vals = data.map((r) => Math.max(0, Number(r[dataKey]) || 0))
+  const total = vals.reduce((a, b) => a + b, 0) || 1
+  let a = TOP
+  return data.map((r, i) => {
+    const span = (vals[i] / total) * TAU
+    const slice = {
+      name: String(r[nameKey] ?? i),
+      value: vals[i],
+      start: a,
+      end: a + span,
+      mid: a + span / 2,
+    }
+    a += span
+    return slice
+  })
+}
+
+/** Which slice a pointer angle falls in (or -1). */
+export function sliceAtAngle(slices: PieSlice[], angle: number): number {
+  // Normalize so comparisons against [start, end) (which begin at TOP) work.
+  let a = angle
+  while (a < TOP) a += TAU
+  while (a >= TOP + TAU) a -= TAU
+  return slices.findIndex((s) => a >= s.start && a < s.end)
+}
+
+export type RadarAxis = { label: string; angle: number }
+
+/** Evenly-spaced spokes, one per data row, labelled by `nameKey`. */
+export function radarAxes(data: Row[], nameKey: string): RadarAxis[] {
+  const n = Math.max(data.length, 1)
+  return data.map((r, i) => ({
+    label: String(r[nameKey] ?? i),
+    angle: TOP + (i / n) * TAU,
+  }))
+}
+
+/** Nearest radar spoke to a pointer angle. */
+export function axisAtAngle(axes: RadarAxis[], angle: number): number {
+  let best = 0
+  let bestD = Infinity
+  axes.forEach((ax, i) => {
+    let d = Math.abs(((angle - ax.angle + Math.PI * 3) % TAU) - Math.PI)
+    d = Math.abs(d)
+    if (d < bestD) {
+      bestD = d
+      best = i
+    }
+  })
+  return best
+}
+
+export const polarX = (cx: number, r: number, angle: number) =>
+  cx + Math.cos(angle) * r
+export const polarY = (cy: number, r: number, angle: number) =>
+  cy + Math.sin(angle) * r
+
+/** Even-odd point-in-polygon test (polygon as flat [x0,y0,x1,y1,…]). */
+export function pointInPolygon(
+  px: number,
+  py: number,
+  poly: number[]
+): boolean {
+  let inside = false
+  const n = poly.length / 2
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    const xi = poly[i * 2]
+    const yi = poly[i * 2 + 1]
+    const xj = poly[j * 2]
+    const yj = poly[j * 2 + 1]
+    if (yi > py !== yj > py && px < ((xj - xi) * (py - yi)) / (yj - yi) + xi) {
+      inside = !inside
+    }
+  }
+  return inside
+}
+
+/** Distance from a point to the nearest edge of a polygon — drives the radial
+ * dither density (dense near the edge, thinning to the centre). */
+export function distToPolygonEdge(
+  px: number,
+  py: number,
+  poly: number[]
+): number {
+  let best = Infinity
+  const n = poly.length / 2
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    const xi = poly[i * 2]
+    const yi = poly[i * 2 + 1]
+    const xj = poly[j * 2]
+    const yj = poly[j * 2 + 1]
+    const dx = xj - xi
+    const dy = yj - yi
+    const len2 = dx * dx + dy * dy || 1
+    let t = ((px - xi) * dx + (py - yi) * dy) / len2
+    t = Math.max(0, Math.min(1, t))
+    const ex = xi + t * dx - px
+    const ey = yi + t * dy - py
+    const d = Math.hypot(ex, ey)
+    if (d < best) best = d
+  }
+  return best
+}

--- a/frontend/src/components/dither/radar-canvas.tsx
+++ b/frontend/src/components/dither/radar-canvas.tsx
@@ -1,0 +1,239 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import {
+  BAYER,
+  backingSize,
+  bloomLayerStyle,
+  easeInOutCubic,
+  OFF_TIER,
+  prefersReducedMotion,
+} from "./dither-paint"
+import { rgb } from "./palette"
+import { distToPolygonEdge, pointInPolygon, polarX, polarY } from "./polar"
+import { usePolarChart } from "./polar-context"
+
+/**
+ * Dither canvas for radar charts. Each series is a closed polygon over the
+ * spokes (value → radius per axis). Backing pixels inside a polygon are filled
+ * with the ordered-dither scatter — dense near the polygon edge, thinning toward
+ * the centre — and each vertex is marked with a bright dot (larger on the hovered
+ * axis). The polygons scale in from the centre on mount.
+ */
+export function RadarCanvas() {
+  const ctx = usePolarChart()
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const bloomRef = useRef<HTMLCanvasElement>(null)
+
+  const { width, height } = ctx.plot
+  const { cols, rows } = backingSize(width, height)
+
+  // The RAF loop reads the latest ctx through a ref; written in an effect
+  // (never during render) — mutating a ref mid-render tears under Strict Mode /
+  // concurrent rendering.
+  const state = useRef(ctx)
+  useEffect(() => {
+    state.current = ctx
+  })
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    const c = canvas?.getContext("2d")
+    if (!(canvas && c) || cols <= 0 || rows <= 0) return
+    canvas.width = cols
+    canvas.height = rows
+
+    const bloomCanvas = bloomRef.current
+    const bloomCtx = bloomCanvas?.getContext("2d") ?? null
+    if (bloomCanvas) {
+      bloomCanvas.width = cols
+      bloomCanvas.height = rows
+    }
+
+    const reduce = prefersReducedMotion()
+    const animate = state.current.animate && !reduce
+    const duration = state.current.animationDuration
+    let raf = 0
+    let animStart = 0
+    let lastProg = -1
+    let lastRevision = state.current.revision
+    let intensity = 0
+    let needsFill = true
+    let lastPaintSig = ""
+    let lastSelected: string | null | undefined = Symbol() as never
+    let lastHover: number | null | undefined = Symbol() as never
+
+    const fx = cols / Math.max(width, 1)
+    const fy = rows / Math.max(height, 1)
+
+    // Build each series polygon in plot coords, scaled by `prog`.
+    const buildPolys = (prog: number) => {
+      const s = state.current
+      const radar = s.radar
+      if (!radar) return []
+      return s.configKeys.map((key) => {
+        const poly: number[] = []
+        const pts: { x: number; y: number }[] = []
+        radar.axes.forEach((ax, i) => {
+          const v = Number(s.data[i]?.[key]) || 0
+          const r = (v / radar.max) * s.outerRadius * prog
+          const x = polarX(s.center.x, r, ax.angle)
+          const y = polarY(s.center.y, r, ax.angle)
+          poly.push(x, y)
+          pts.push({ x, y })
+        })
+        return { key, poly, pts }
+      })
+    }
+
+    const paint = (prog: number) => {
+      const s = state.current
+      if (!s.radar) return
+      c.clearRect(0, 0, cols, rows)
+      const polys = buildPolys(easeInOutCubic(prog))
+      const band = Math.max(s.outerRadius * 0.45, 1)
+
+      for (let y = 0; y < rows; y++) {
+        const py = ((y + 0.5) * height) / rows
+        for (let x = 0; x < cols; x++) {
+          const px = ((x + 0.5) * width) / cols
+          // Whether a layer behind already coloured this pixel — front layers
+          // then keep true gaps in their dither so the back layer shows
+          // through, instead of tinting the overlap into a muddy blend.
+          let covered = false
+          for (let pi = 0; pi < polys.length; pi++) {
+            const { key, poly } = polys[pi]
+            if (!pointInPolygon(px, py, poly)) continue
+            const seed = s.seedOf(key)
+            const variant = s.variantOf(key)
+            const emphasis = s.selectedDataKey ?? s.focusDataKey
+            const selDim = emphasis !== null && emphasis !== key ? 0.3 : 1
+            const dist = distToPolygonEdge(px, py, poly)
+            if (dist < 1.4) {
+              c.fillStyle = rgb(seed.fill, 1, selDim)
+              c.fillRect(x, y, 1, 1)
+              covered = true
+              continue
+            }
+            const density = 1 - Math.min(1, dist / band)
+            const bias = variant === "dotted" ? 0.12 : 0
+            // Thin each successive (front) layer so overlapping polygons
+            // read as distinct layers, not a muddy blend.
+            const sparse = pi * 0.2
+            if (variant === "hatched" && ((x + y) & 3) >= 2) continue
+            const lit =
+              variant === "solid" ||
+              density > BAYER[y & 3][x & 3] - 0.1 * intensity - bias + sparse
+            // Unlit cells: over another layer, stay a real gap (back layer
+            // shows through); over bare background, paint the faint tier so
+            // the page never bleeds in.
+            if (!lit && (variant === "dotted" || covered)) continue
+            const k = (0.32 + density * 0.68) * (1 + 0.22 * intensity)
+            const alpha = Math.min(1, (lit ? k : k * OFF_TIER) * selDim)
+            c.fillStyle = rgb(seed.fill, 1, alpha)
+            c.fillRect(x, y, 1, 1)
+            covered = true
+          }
+        }
+      }
+
+      // Vertex markers — larger on the hovered axis.
+      for (const { key, pts } of polys) {
+        const seed = s.seedOf(key)
+        const emphasis = s.selectedDataKey ?? s.focusDataKey
+        const selDim = emphasis !== null && emphasis !== key ? 0.3 : 1
+        pts.forEach((p, i) => {
+          const bx = Math.round(p.x * fx)
+          const by = Math.round(p.y * fy)
+          const big = s.hoverIndex === i
+          c.fillStyle = rgb(seed.fill, 1, selDim)
+          const sz = big ? 2 : 1
+          c.fillRect(bx - (sz - 1), by - (sz - 1), sz * 2 - 1, sz * 2 - 1)
+        })
+      }
+    }
+
+    const draw = (now: number) => {
+      raf = requestAnimationFrame(draw)
+      const s = state.current
+      if (!s.ready || !s.radar) return
+      if (bloomCtx) {
+        const on = s.bloom !== "off" && (!s.bloomOnHover || s.isMouseInChart)
+        if (on) {
+          bloomCtx.clearRect(0, 0, cols, rows)
+          bloomCtx.drawImage(canvas, 0, 0)
+        }
+      }
+      if (s.revision !== lastRevision) {
+        lastRevision = s.revision
+        animStart = 0
+        lastProg = -1
+      }
+      if (!animStart) animStart = now
+      const prog = animate ? Math.min(1, (now - animStart) / duration) : 1
+
+      const emphasisNow = s.selectedDataKey ?? s.focusDataKey
+      if (emphasisNow !== lastSelected) {
+        lastSelected = emphasisNow
+        needsFill = true
+      }
+      if (s.hoverIndex !== lastHover) {
+        lastHover = s.hoverIndex
+        needsFill = true
+      }
+      const itTarget = s.isMouseInChart ? 1 : 0
+      if (Math.abs(intensity - itTarget) > 0.001) {
+        intensity += (itTarget - intensity) * (reduce ? 1 : 0.16)
+        needsFill = true
+      } else intensity = itTarget
+      if (prog !== lastProg) {
+        lastProg = prog
+        needsFill = true
+      }
+
+      // Live tweak repaint (variant) without replaying the scale-in.
+      const paintSig = s.configKeys.map((k) => s.variantOf(k)).join(",")
+      if (paintSig !== lastPaintSig) {
+        lastPaintSig = paintSig
+        needsFill = true
+      }
+
+      if (!needsFill) return
+      paint(prog)
+      needsFill = false
+    }
+
+    raf = requestAnimationFrame(draw)
+    return () => cancelAnimationFrame(raf)
+  }, [cols, rows, width, height])
+
+  const bloom = bloomLayerStyle(
+    ctx.bloom,
+    ctx.bloomOnHover ? ctx.isMouseInChart : true
+  )
+  const pos = {
+    left: ctx.margins.left,
+    top: ctx.margins.top,
+    width,
+    height,
+  } as const
+
+  return (
+    <>
+      <canvas
+        ref={canvasRef}
+        className="pointer-events-none absolute"
+        style={{ ...pos, imageRendering: "pixelated" }}
+      />
+      <canvas
+        ref={bloomRef}
+        className="pointer-events-none absolute"
+        style={{
+          ...pos,
+          transition: "opacity 220ms ease",
+          ...(bloom ?? { opacity: 0 }),
+        }}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/dither/radar-chart.tsx
+++ b/frontend/src/components/dither/radar-chart.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import type { ReactNode } from "react"
+import type { ChartConfig, Margins } from "./chart-context"
+import type { BloomInput } from "./dither-paint"
+import { PolarRoot } from "./polar-root"
+import { RadarCanvas } from "./radar-canvas"
+import { RadarFrame } from "./radar-frame"
+
+// `object` rather than `Record<string, unknown>`: interfaces don't get an
+// implicit index signature, so interface-typed rows failed to satisfy the
+// generic. Internal layers still index rows through their own Row type.
+type Row = object
+
+export type RadarChartProps<TData extends Row> = {
+  data: TData[]
+  config: ChartConfig
+  children: ReactNode
+  nameKey: string // axis-label field
+  margins?: Partial<Margins>
+  className?: string
+  animate?: boolean
+  animationDuration?: number
+  replayToken?: number
+  bloom?: BloomInput
+  bloomOnHover?: boolean
+  defaultSelectedDataKey?: string | null
+  onSelectionChange?: (key: string | null) => void
+}
+
+/** Composable dither **radar** chart. Compose `<Radar>` series, `<Legend>`, … inside. */
+export function RadarChart<TData extends Row>(props: RadarChartProps<TData>) {
+  return (
+    <PolarRoot
+      chartType="radar"
+      Canvas={RadarCanvas}
+      backDecoration={<RadarFrame />}
+      dataKey=""
+      {...props}
+    />
+  )
+}

--- a/frontend/src/components/dither/radar-frame.tsx
+++ b/frontend/src/components/dither/radar-frame.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { polarX, polarY } from "./polar"
+import { usePolarChart } from "./polar-context"
+
+const LEVELS = 4
+
+/** Built-in radar chrome: concentric polygon rings, spokes, and axis labels.
+ * Rendered behind the dither canvas by the radar root. */
+export function RadarFrame() {
+  const ctx = usePolarChart()
+  if (!ctx.ready || !ctx.radar) return null
+  const { axes } = ctx.radar
+  const { x: cx, y: cy } = ctx.center
+  const R = ctx.outerRadius
+
+  const ring = (radius: number) =>
+    `${axes
+      .map(
+        (ax, i) =>
+          `${i === 0 ? "M" : "L"}${polarX(cx, radius, ax.angle).toFixed(1)},${polarY(cy, radius, ax.angle).toFixed(1)}`
+      )
+      .join(" ")} Z`
+
+  return (
+    <g>
+      <g className="stroke-border" fill="none">
+        {Array.from({ length: LEVELS }, (_, l) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: fixed ring levels
+          <path key={l} d={ring((R * (l + 1)) / LEVELS)} />
+        ))}
+        {axes.map((ax, i) => (
+          <line
+            key={ax.label}
+            x1={cx}
+            y1={cy}
+            x2={polarX(cx, R, ax.angle)}
+            y2={polarY(cy, R, ax.angle)}
+            className={ctx.hoverIndex === i ? "stroke-foreground" : undefined}
+          />
+        ))}
+      </g>
+      <g className="font-mono text-[10px]">
+        {axes.map((ax, i) => {
+          const lx = polarX(cx, R + 10, ax.angle)
+          const ly = polarY(cy, R + 10, ax.angle)
+          const anchor =
+            Math.abs(Math.cos(ax.angle)) < 0.3
+              ? "middle"
+              : Math.cos(ax.angle) > 0
+                ? "start"
+                : "end"
+          const hot = ctx.hoverIndex === i
+          return (
+            <text
+              key={ax.label}
+              x={lx}
+              y={ly}
+              textAnchor={anchor}
+              dominantBaseline="central"
+              className={hot ? "fill-foreground" : "fill-muted-foreground"}
+            >
+              {ax.label}
+            </text>
+          )
+        })}
+      </g>
+    </g>
+  )
+}
+
+RadarFrame.chartLayer = "back" as const

--- a/frontend/src/components/dither/radar.tsx
+++ b/frontend/src/components/dither/radar.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { useEffect } from "react"
+import type { AreaVariant } from "./chart-context"
+import { usePolarPart } from "./polar-context"
+
+export type RadarProps = {
+  dataKey: string
+  variant?: AreaVariant
+}
+
+/**
+ * One radar series — a closed polygon over the spokes. Sets this series' fill
+ * variant; the dithered polygon is painted on the canvas.
+ */
+export function Radar({ dataKey, variant = "gradient" }: RadarProps) {
+  const ctx = usePolarPart("Radar", "radar")
+  const { registerVariant, unregisterVariant } = ctx
+
+  if (import.meta.env.DEV && !ctx.config[dataKey]) {
+    console.warn(
+      `<Radar dataKey="${dataKey}" />: "${dataKey}" is not in the chart \`config\`. Add it so the series has a colour and label.`
+    )
+  }
+
+  useEffect(() => {
+    registerVariant(dataKey, variant)
+    return () => unregisterVariant(dataKey)
+  }, [dataKey, variant, registerVariant, unregisterVariant])
+
+  return null
+}

--- a/frontend/src/components/dither/scales.ts
+++ b/frontend/src/components/dither/scales.ts
@@ -1,0 +1,89 @@
+// Pure geometry helpers for the dither chart engine. Kept framework-free so the
+// context (and, later, bar/line/pie/radar roots) can share the same math.
+
+import { scaleBand, scaleLinear, scalePoint } from "d3-scale"
+import { stack as d3Stack, stackOffsetExpand } from "d3-shape"
+
+export type StackType = "default" | "stacked" | "percent"
+
+type Row = Record<string, unknown>
+
+const num = (v: unknown) =>
+  typeof v === "number" && Number.isFinite(v) ? v : 0
+
+/**
+ * Per-series [y0, y1] bands for every row. For `default` every series sits on
+ * the floor (y0 = 0); for `stacked`/`percent` they pile on top of each other
+ * via d3's stack layout. The shape `bands[key][i] = [y0, y1]` is what both the
+ * SVG area paths and the canvas overlay read from.
+ */
+export function computeBands(
+  data: Row[],
+  keys: string[],
+  stackType: StackType
+): { bands: Record<string, [number, number][]>; max: number } {
+  if (stackType === "default") {
+    const bands: Record<string, [number, number][]> = {}
+    let max = 0
+    for (const key of keys) {
+      bands[key] = data.map((row) => {
+        const v = num(row[key])
+        if (v > max) max = v
+        return [0, v]
+      })
+    }
+    return { bands: bands, max: max || 1 }
+  }
+
+  const series = d3Stack<Row>()
+    .keys(keys)
+    .value((row, key) => num(row[key]))
+    .offset(stackType === "percent" ? stackOffsetExpand : (undefined as never))(
+    data
+  )
+
+  const bands: Record<string, [number, number][]> = {}
+  let max = 0
+  series.forEach((layer) => {
+    bands[layer.key] = layer.map((point) => {
+      if (point[1] > max) max = point[1]
+      return [point[0], point[1]]
+    })
+  })
+  return { bands, max: max || 1 }
+}
+
+/** x positions for each row index, evenly spread across the plot width. */
+export function buildXScale(length: number, plotWidth: number) {
+  return scalePoint<number>()
+    .domain(Array.from({ length }, (_, i) => i))
+    .range([0, plotWidth])
+}
+
+/** Banded x for bar categories — each index owns a slot of `bandwidth` width. */
+export function buildBandScale(length: number, plotWidth: number) {
+  return scaleBand<number>()
+    .domain(Array.from({ length }, (_, i) => i))
+    .range([0, plotWidth])
+    .paddingInner(0.28)
+    .paddingOuter(0.18)
+}
+
+/** Index of the category whose band a horizontal pixel offset falls in. */
+export function indexAtBand(px: number, length: number, plotWidth: number) {
+  if (length <= 0 || plotWidth <= 0) return 0
+  const t = Math.max(0, Math.min(0.999, px / plotWidth))
+  return Math.min(length - 1, Math.floor(t * length))
+}
+
+/** value → vertical pixel, with the floor at the bottom of the plot. */
+export function buildYScale(max: number, plotHeight: number) {
+  return scaleLinear().domain([0, max]).nice().range([plotHeight, 0])
+}
+
+/** Index of the row nearest a horizontal pixel offset within the plot. */
+export function nearestIndex(px: number, length: number, plotWidth: number) {
+  if (length <= 1 || plotWidth <= 0) return 0
+  const t = Math.max(0, Math.min(1, px / plotWidth))
+  return Math.round(t * (length - 1))
+}

--- a/frontend/src/components/dither/series-context.tsx
+++ b/frontend/src/components/dither/series-context.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import { createContext, use } from "react"
+import type { Seed } from "./palette"
+
+export type SeriesContextValue = {
+  dataKey: string
+  seed: Seed
+  dimmed: boolean
+}
+
+export const SeriesContext = createContext<SeriesContextValue | null>(null)
+
+/** Boundary guard for series-scoped markers (`<Dot>`, `<ActiveDot>`). */
+export function useSeries(part: string) {
+  const ctx = use(SeriesContext)
+  if (!ctx) {
+    throw new Error(
+      `<${part} /> must be rendered inside a series (e.g. <Area />).`
+    )
+  }
+  return ctx
+}

--- a/frontend/src/components/dither/sparkline.tsx
+++ b/frontend/src/components/dither/sparkline.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import "./dither.css"
+import { useMemo } from "react"
+import { Area } from "./area"
+import { AreaChart } from "./area-chart"
+import type { AreaVariant } from "./chart-context"
+import type { BloomInput } from "./dither-paint"
+import type { DitherColor } from "./palette"
+
+export type SparklineProps = {
+  /** Plain numeric series — the common sparkline case. */
+  data: number[]
+  color: DitherColor
+  variant?: AreaVariant
+  /** Controlled crosshair position (e.g. a committed point). */
+  markerIndex?: number | null
+  /** Parent-driven hover (e.g. the whole card/row) — lifts the fill. */
+  hovered?: boolean
+  /** Glow on the dither fill. */
+  bloom?: BloomInput
+  /** Only bloom while hovered. */
+  bloomOnHover?: boolean
+  /** Play the entrance sweep — off by default for a calm spark. */
+  animate?: boolean
+  className?: string
+}
+
+/**
+ * Thin wrapper over {@link AreaChart} for the decorative-sparkline case: a
+ * single `number[]` series, no axes/grid/tooltip, no scrub crosshair (unless a
+ * `markerIndex` is supplied). Keeps the hover brightness lift.
+ */
+export function Sparkline({
+  data,
+  color,
+  variant = "gradient",
+  markerIndex = null,
+  hovered = false,
+  bloom = "off",
+  bloomOnHover = false,
+  animate = false,
+  className,
+}: SparklineProps) {
+  // Memoized explicitly so the chart works without React Compiler: `rows`
+  // identity drives the entrance-replay revision, so a fresh array every
+  // render would re-trigger the revision's state adjustment each pass.
+  const rows = useMemo(() => data.map((v) => ({ v })), [data])
+  const config = useMemo(() => ({ v: { color } }), [color])
+
+  return (
+    <AreaChart
+      data={rows}
+      config={config}
+      interactive={false}
+      animate={animate}
+      markerIndex={markerIndex}
+      hovered={hovered}
+      bloom={bloom}
+      bloomOnHover={bloomOnHover}
+      margins={{ top: 0, right: 0, bottom: 0, left: 0 }}
+      className={"dither-root " + (className ?? "")}
+    >
+      <Area dataKey="v" variant={variant} />
+    </AreaChart>
+  )
+}

--- a/frontend/src/components/dither/tooltip.tsx
+++ b/frontend/src/components/dither/tooltip.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import { AnimatePresence, motion } from "motion/react"
+import { useState } from "react"
+import { useCommonChart } from "./common-context"
+import { cn } from "./lib"
+import { rgb } from "./palette"
+
+export type TooltipVariant = "default" | "frosted-glass"
+
+const VARIANT: Record<TooltipVariant, string> = {
+  default: "bg-popover",
+  "frosted-glass": "bg-popover/70 backdrop-blur-sm",
+}
+
+/**
+ * Floating hover tooltip. Reads the shared common context so it works in every
+ * chart family. It glides between points and fades in/out (instead of snapping),
+ * and dims unselected series/slices.
+ */
+export function Tooltip({
+  labelKey,
+  valueFormatter,
+  variant = "default",
+}: {
+  labelKey?: string
+  valueFormatter?: (value: number, name: string) => string
+  variant?: TooltipVariant
+}) {
+  const chart = useCommonChart()
+  const show = chart.ready && chart.hoverIndex != null
+
+  // Retain the last hovered index so the card keeps its content while fading
+  // out — adjust-state-during-render (no refs in render).
+  const [lastIndex, setLastIndex] = useState(0)
+  if (chart.hoverIndex != null && chart.hoverIndex !== lastIndex) {
+    setLastIndex(chart.hoverIndex)
+  }
+  const index = chart.hoverIndex ?? lastIndex
+
+  const heading = chart.heading(index, labelKey)
+  const items = chart.itemsAt(index)
+
+  return (
+    <AnimatePresence>
+      {show && items.length > 0 && (
+        <motion.div
+          key="dither-tooltip"
+          initial={{
+            opacity: 0,
+            x: "-50%",
+            y: "-115%",
+            top: chart.tooltipTop,
+            left: chart.tooltipLeft,
+          }}
+          animate={{
+            opacity: 1,
+            x: "-50%",
+            y: "-115%",
+            top: chart.tooltipTop,
+            left: chart.tooltipLeft,
+          }}
+          exit={{ opacity: 0 }}
+          transition={{
+            type: "spring",
+            stiffness: 520,
+            damping: 38,
+            mass: 0.6,
+          }}
+          className={cn(
+            "pointer-events-none absolute z-10 rounded-md border px-2 py-1 shadow-sm",
+            VARIANT[variant]
+          )}
+        >
+          {heading && (
+            <div className="mb-0.5 font-mono text-[10px] text-muted-foreground">
+              {heading}
+            </div>
+          )}
+          <div className="flex flex-col gap-0.5">
+            {items.map((item) => (
+              <div
+                key={item.name}
+                className="flex items-center gap-1.5 font-mono text-[11px] text-popover-foreground tabular-nums"
+                style={{ opacity: item.dimmed ? 0.4 : 1 }}
+              >
+                <span
+                  className="size-2 rounded-[1px]"
+                  style={{ backgroundColor: rgb(item.seed.fill) }}
+                />
+                <span className="text-muted-foreground">{item.label}</span>
+                <span className="ml-auto pl-2 text-foreground">
+                  {valueFormatter
+                    ? valueFormatter(item.value, item.name)
+                    : item.value.toLocaleString()}
+                </span>
+              </div>
+            ))}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}
+
+Tooltip.chartLayer = "dom" as const

--- a/frontend/src/components/dither/use-chart-dimensions.ts
+++ b/frontend/src/components/dither/use-chart-dimensions.ts
@@ -1,0 +1,37 @@
+import { useLayoutEffect, useRef, useState } from "react"
+
+export type Dimensions = { width: number; height: number }
+
+/**
+ * Tracks an element's CSS pixel size via {@link ResizeObserver}. Uses
+ * `clientWidth`/`clientHeight` (the layout size) rather than
+ * `getBoundingClientRect()` so a parent `layoutId` morph — which scales the
+ * element via a transform — can't trick the chart into measuring a scaled size
+ * and locking its canvas to it.
+ */
+export function useChartDimensions<T extends HTMLElement>() {
+  const ref = useRef<T>(null)
+  const [size, setSize] = useState<Dimensions>({ width: 0, height: 0 })
+
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const measure = () => {
+      const width = Math.max(0, el.clientWidth)
+      const height = Math.max(0, el.clientHeight)
+      setSize((prev) =>
+        prev.width === width && prev.height === height
+          ? prev // guard against repeat fires
+          : { width, height }
+      )
+    }
+
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    measure()
+    return () => ro.disconnect()
+  }, [])
+
+  return { ref, size }
+}

--- a/frontend/src/components/dither/x-axis.tsx
+++ b/frontend/src/components/dither/x-axis.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { useChartPart } from "./chart-context"
+
+export function XAxis({
+  dataKey,
+  tickFormatter,
+  tickMargin = 8,
+  maxTicks = 8,
+}: {
+  dataKey?: string
+  tickFormatter?: (value: unknown, index: number) => string
+  tickMargin?: number
+  maxTicks?: number
+}) {
+  const ctx = useChartPart("XAxis")
+  if (!ctx.ready) return null
+
+  const step = Math.max(1, Math.ceil(ctx.dataLength / maxTicks))
+  const y = ctx.plot.height + tickMargin
+
+  return (
+    <g className="fill-current font-mono text-[10px] text-muted-foreground">
+      {ctx.data.map((row, i) => {
+        if (i % step !== 0) return null
+        const raw = dataKey ? row[dataKey] : i
+        const label = tickFormatter ? tickFormatter(raw, i) : String(raw ?? "")
+        return (
+          <text
+            // biome-ignore lint/suspicious/noArrayIndexKey: index is the stable x position
+            key={i}
+            x={ctx.xCenter(i) ?? 0}
+            y={y}
+            textAnchor="middle"
+            dominantBaseline="hanging"
+            fill="currentColor"
+          >
+            {label}
+          </text>
+        )
+      })}
+    </g>
+  )
+}

--- a/frontend/src/components/dither/y-axis.tsx
+++ b/frontend/src/components/dither/y-axis.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { useChartPart } from "./chart-context"
+
+export function YAxis({
+  tickFormatter,
+  tickCount = 4,
+  tickMargin = 8,
+}: {
+  tickFormatter?: (value: number) => string
+  tickCount?: number
+  tickMargin?: number
+}) {
+  const ctx = useChartPart("YAxis")
+  if (!ctx.ready) return null
+
+  return (
+    <g className="fill-current font-mono text-[10px] text-muted-foreground">
+      {ctx.y.ticks(tickCount).map((t) => (
+        <text
+          key={t}
+          x={-tickMargin}
+          y={ctx.y(t)}
+          textAnchor="end"
+          dominantBaseline="central"
+          fill="currentColor"
+        >
+          {tickFormatter ? tickFormatter(t) : t}
+        </text>
+      ))}
+    </g>
+  )
+}

--- a/frontend/src/components/stats/UserStats.tsx
+++ b/frontend/src/components/stats/UserStats.tsx
@@ -1,10 +1,23 @@
-import React, { useCallback, useEffect, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import * as echarts from 'echarts';
 import styles from './UserStats.module.css';
 import CharacterDisplay from '../CharacterDisplay';
 import { LoadingState, ErrorState } from '../Feedback';
 import { stageImages } from '../../lib/stages';
+import {
+  ActiveDot,
+  Bar,
+  BarChart,
+  DitherHeatmap,
+  Legend,
+  Line,
+  LineChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+  type DitherColor,
+  type DitherHeatmapCell,
+} from '../dither';
 
 interface CharacterStats {
   character: string;
@@ -47,6 +60,31 @@ interface UserStatsData {
   mostFacedCharacters: MostFacedCharacter[];
 }
 
+interface TimelineInfo {
+  game_numbers: number[];
+  win_rates: number[];
+  date_ranges?: string[];
+}
+
+interface HeatmapPoint {
+  hour: number;
+  day: number;
+  win_rate: number;
+  game_count: number;
+}
+
+interface TimelineRow {
+  game: string;
+  label: string;
+  winRate: number;
+}
+
+interface CharacterRow {
+  character: string;
+  winRate: number;
+  usage: number;
+}
+
 // Seeded random number generator for consistent simulated data
 function seededRandom(seed: number) {
   let value = seed;
@@ -56,21 +94,79 @@ function seededRandom(seed: number) {
   };
 }
 
+// Simulated fallback timeline that trends around the overall win rate
+function buildSimulatedTimeline(
+  seed: number,
+  totalGames: number,
+  overallWinRate: number
+): TimelineRow[] {
+  const random = seededRandom(seed);
+  const numPoints = Math.min(100, Math.floor(totalGames / 20));
+  const rows: TimelineRow[] = [];
+  let currentValue = overallWinRate + (random() - 0.5) * 20;
+
+  for (let i = 0; i < numPoints; i++) {
+    // Add some randomness but keep it smooth
+    const change = (random() - 0.5) * 15;
+    currentValue = Math.max(20, Math.min(80, currentValue + change));
+
+    // Gradually pull towards overall win rate for realism
+    currentValue = currentValue * 0.92 + overallWinRate * 0.08;
+
+    rows.push({
+      game: `${i + 1}`,
+      label: `Window ${i + 1}`,
+      winRate: parseFloat(currentValue.toFixed(1)),
+    });
+  }
+
+  return rows;
+}
+
+// Simulated fallback heatmap with realistic gaming patterns (evening-heavy)
+function buildSimulatedHeatmapCells(seed: number): DitherHeatmapCell[] {
+  const random = seededRandom(seed);
+  const cells: DitherHeatmapCell[] = [];
+
+  for (let d = 0; d < 7; d++) {
+    for (let h = 0; h < 24; h++) {
+      let baseValue = random() * 40;
+      let gameCount = Math.floor(random() * 5);
+
+      if (h >= 18 && h <= 23) {
+        baseValue += 40; // Evening boost
+        gameCount += Math.floor(random() * 20) + 5;
+      } else if (h >= 12 && h < 18) {
+        baseValue += 20; // Afternoon boost
+        gameCount += Math.floor(random() * 10) + 2;
+      } else if (h >= 0 && h < 6) {
+        baseValue -= 20; // Late night penalty
+        gameCount = Math.floor(random() * 3);
+      }
+
+      const winRate = Math.max(0, Math.min(100, baseValue + random() * 30));
+      cells.push({
+        day: d,
+        hour: h,
+        winRate: gameCount === 0 ? null : Math.round(winRate),
+        games: gameCount,
+      });
+    }
+  }
+
+  return cells;
+}
+
 export const UserStats: React.FC = () => {
   const { username = '' } = useParams<{ username: string }>();
   const [stats, setStats] = useState<UserStatsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [heatmapData, setHeatmapData] = useState<any>(null);
+  const [heatmapData, setHeatmapData] = useState<HeatmapPoint[] | null>(null);
   const [usingSimulatedData, setUsingSimulatedData] = useState(false);
   const [selectedCharacter, setSelectedCharacter] = useState<string | null>(null);
-  const [timelineData, setTimelineData] = useState<any>(null);
+  const [timelineData, setTimelineData] = useState<TimelineInfo | null>(null);
   const [usingSimulatedTimeline, setUsingSimulatedTimeline] = useState(false);
-  
-  // Refs for ECharts - must be declared before any early returns
-  const winRateTimelineRef = useRef<HTMLDivElement>(null);
-  const performanceHeatmapRef = useRef<HTMLDivElement>(null);
-  const characterChartRef = useRef<HTMLDivElement>(null);
 
   const fetchStats = useCallback(async () => {
     if (!username) {
@@ -157,387 +253,6 @@ export const UserStats: React.FC = () => {
     fetchHeatmapData();
   }, [username, selectedCharacter]);
 
-  // Initialize ECharts visualizations
-  useEffect(() => {
-    if (!stats) return;
-
-    // Win Rate Timeline Chart
-    if (winRateTimelineRef.current) {
-      const chart = echarts.init(winRateTimelineRef.current);
-      
-      let xData: string[];
-      let yData: number[];
-      let dateRanges: string[] = [];
-      
-      if (timelineData && !usingSimulatedTimeline) {
-        // Use real data from backend
-        xData = timelineData.game_numbers.map((n: number) => `${n}`);
-        yData = timelineData.win_rates;
-        dateRanges = timelineData.date_ranges || [];
-      } else {
-        // Generate seeded random data for consistent display
-        const seed = (username?.charCodeAt(0) || 0) * 1000;
-        const random = seededRandom(seed);
-        
-        // Generate 100 data points (or fewer if not enough games)
-        const numPoints = Math.min(100, Math.floor(stats.totalGames / 20));
-        xData = Array.from({ length: numPoints }, (_, i) => `${i + 1}`);
-        
-        // Create simulated data that trends around overall win rate
-        const baseWinRate = stats.overallWinRate;
-        yData = [];
-        let currentValue = baseWinRate + (random() - 0.5) * 20;
-        
-        for (let i = 0; i < numPoints; i++) {
-          // Add some randomness but keep it smooth
-          const change = (random() - 0.5) * 15;
-          currentValue = Math.max(20, Math.min(80, currentValue + change));
-          
-          // Gradually pull towards overall win rate for realism
-          currentValue = currentValue * 0.92 + baseWinRate * 0.08;
-          
-          yData.push(parseFloat(currentValue.toFixed(1)));
-        }
-      }
-
-      chart.setOption({
-        backgroundColor: 'transparent',
-        tooltip: {
-          trigger: 'axis',
-          backgroundColor: '#3c3836',
-          borderColor: '#504945',
-          textStyle: { color: '#ebdbb2', fontSize: 11 },
-          formatter: (params: any) => {
-            const point = params[0];
-            const windowIndex = point.dataIndex;
-            let tooltip = `20-Game Win Rate: ${point.value.toFixed(1)}%`;
-            
-            // Add date range if available
-            if (dateRanges.length > windowIndex) {
-              tooltip += `<br/>Period: ${dateRanges[windowIndex]}`;
-            }
-            
-            return tooltip;
-          }
-        },
-        grid: { left: '8%', right: '12%', top: '15%', bottom: '12%', containLabel: true },
-        xAxis: {
-          type: 'category',
-          data: xData,
-          axisLine: { lineStyle: { color: '#504945' } },
-          axisLabel: { color: '#a89984', fontSize: 9, interval: Math.floor(xData.length / 10) },
-          name: '20-Game Windows (Last 2000 Games)',
-          nameTextStyle: { color: '#a89984', fontSize: 10 },
-          nameLocation: 'middle',
-          nameGap: 25
-        },
-        yAxis: {
-          type: 'value',
-          axisLine: { lineStyle: { color: '#504945' } },
-          axisLabel: { color: '#a89984', fontSize: 9, formatter: '{value}%' },
-          splitLine: { lineStyle: { color: '#3c3836', type: 'dashed' } },
-          min: 0,
-          max: 100
-        },
-        series: [{
-          data: yData,
-          type: 'line',
-          smooth: true,
-          symbol: 'none',
-          lineStyle: { color: username === 'Shayne' ? '#fe8019' : '#b8bb26', width: 2 },
-          areaStyle: {
-            color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-              { offset: 0, color: username === 'Shayne' ? 'rgba(254, 128, 25, 0.3)' : 'rgba(184, 187, 38, 0.3)' },
-              { offset: 1, color: 'rgba(60, 56, 54, 0.1)' }
-            ])
-          },
-          markLine: {
-            silent: true,
-            symbol: 'none',
-            data: [
-              {
-                yAxis: 50,
-                lineStyle: { color: 'rgba(168, 153, 132, 0.2)', type: 'dashed', width: 1 },
-                label: { show: false }
-              },
-              {
-                yAxis: stats.overallWinRate,
-                lineStyle: { color: '#83a598', type: 'solid', width: 1 },
-                label: { formatter: 'Overall Avg: {c}%', color: '#83a598', fontSize: 9 }
-              }
-            ]
-          }
-        }]
-      });
-
-      const resizeObserver = new ResizeObserver(() => chart.resize());
-      resizeObserver.observe(winRateTimelineRef.current);
-
-      return () => {
-        resizeObserver.disconnect();
-        chart.dispose();
-      };
-    }
-  }, [stats, username, timelineData, usingSimulatedTimeline]);
-
-  useEffect(() => {
-    if (!stats) return;
-
-    // Performance Heatmap (Day of Week vs Hour) - More granular with 24 hours
-    if (performanceHeatmapRef.current) {
-      const chart = echarts.init(performanceHeatmapRef.current);
-      
-      const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-      const hours = Array.from({ length: 24 }, (_, i) => {
-        if (i === 0) return '12a';
-        if (i < 12) return `${i}a`;
-        if (i === 12) return '12p';
-        return `${i - 12}p`;
-      });
-      
-      // Format: [hour, day, winRate, gameCount]
-      let data: [number, number, number, number][] = [];
-      let maxGames = 30;
-      
-      if (heatmapData && !usingSimulatedData) {
-        // Use real data from backend
-        data = heatmapData.map((item: any) => [
-          item.hour,
-          item.day,
-          item.win_rate,
-          item.game_count
-        ]);
-        
-        // Calculate actual max games for normalization
-        maxGames = Math.max(...heatmapData.map((item: any) => item.game_count), 1);
-      } else {
-        // Use seeded random data for consistent display
-        const random = seededRandom(username.charCodeAt(0) * 1000);
-        
-      for (let d = 0; d < 7; d++) {
-          for (let h = 0; h < 24; h++) {
-            // Simulate realistic gaming patterns (higher activity in evenings)
-            let baseValue = random() * 40;
-            let gameCount = Math.floor(random() * 5); // Base game count
-            
-            if (h >= 18 && h <= 23) {
-              baseValue += 40; // Evening boost
-              gameCount += Math.floor(random() * 20) + 5; // More games in evening
-            } else if (h >= 12 && h < 18) {
-              baseValue += 20; // Afternoon boost
-              gameCount += Math.floor(random() * 10) + 2; // Some games in afternoon
-            } else if (h >= 0 && h < 6) {
-              baseValue -= 20; // Late night penalty
-              gameCount = Math.floor(random() * 3); // Very few games late night
-            }
-            
-            const winRate = Math.max(0, Math.min(100, baseValue + (random() * 30)));
-            data.push([h, d, Math.round(winRate), gameCount]);
-          }
-        }
-      }
-
-      chart.setOption({
-        backgroundColor: 'transparent',
-        tooltip: {
-          position: 'top',
-          backgroundColor: '#3c3836',
-          borderColor: '#504945',
-          textStyle: { color: '#ebdbb2', fontSize: 11 },
-          formatter: (params: any) => {
-            const winRate = params.value[2];
-            const games = params.value[3];
-            if (games === 0) {
-              return `${days[params.value[1]]} ${hours[params.value[0]]}<br/>No games played`;
-            }
-            return `${days[params.value[1]]} ${hours[params.value[0]]}<br/>Win Rate: ${winRate}%<br/>Games: ${games}`;
-          }
-        },
-        grid: { left: '8%', right: '2%', top: '3%', bottom: '15%', containLabel: true },
-        xAxis: {
-          type: 'category',
-          data: hours,
-          splitArea: { show: false },
-          axisLine: { show: false },
-          axisTick: { show: false },
-          axisLabel: { 
-            color: '#a89984', 
-            fontSize: 9,
-            interval: 2, // Show every 3rd hour
-            rotate: 0
-          }
-        },
-        yAxis: {
-          type: 'category',
-          data: days,
-          splitArea: { show: false },
-          axisLine: { show: false },
-          axisTick: { show: false },
-          axisLabel: { color: '#a89984', fontSize: 10 },
-          inverse: true // Display from top to bottom (Sunday at top, Saturday at bottom)
-        },
-        visualMap: {
-          show: false, // Hide the visual map since we're using custom colors
-          min: 0,
-          max: 100
-        },
-        series: [{
-          type: 'heatmap',
-          data: data.map(item => {
-            const [hour, day, winRate, gameCount] = item;
-            
-            // Special handling for cells with no games
-            if (gameCount === 0) {
-              // Use neutral yellow color with very low opacity
-              return {
-                value: [hour, day, 50, 0], // Show as 50% win rate
-                itemStyle: {
-                  color: 'rgba(250, 189, 47, 0.05)' // Yellow with 5% opacity
-                }
-              };
-            }
-            
-            // Calculate brightness based on game count (0.3 to 1.0)
-            // More games = brighter, fewer games = darker
-            const brightness = Math.max(0.3, Math.min(1.0, gameCount / maxGames));
-            
-            // Determine color based on win rate
-            let baseColor;
-            if (winRate < 35) {
-              baseColor = [251, 73, 52]; // Red (#fb4934)
-            } else if (winRate < 45) {
-              baseColor = [254, 128, 25]; // Orange (#fe8019)
-            } else if (winRate < 55) {
-              baseColor = [250, 189, 47]; // Yellow (#fabd2f)
-            } else if (winRate < 65) {
-              baseColor = [184, 187, 38]; // Light green (#b8bb26)
-            } else {
-              baseColor = [152, 151, 26]; // Dark green (#98971a)
-            }
-            
-            // Apply brightness to the color
-            const adjustedColor = baseColor.map(c => Math.round(c * brightness));
-            const colorString = `rgb(${adjustedColor[0]}, ${adjustedColor[1]}, ${adjustedColor[2]})`;
-            
-            return {
-              value: [hour, day, winRate, gameCount],
-              itemStyle: {
-                color: colorString
-              }
-            };
-          }),
-          label: { show: false },
-          itemStyle: {
-            borderColor: '#282828',
-            borderWidth: 1
-          },
-          emphasis: {
-            itemStyle: {
-              shadowBlur: 10,
-              shadowColor: 'rgba(0, 0, 0, 0.5)',
-              borderColor: '#fbf1c7',
-              borderWidth: 2
-            }
-          }
-        }]
-      });
-
-      const resizeObserver = new ResizeObserver(() => chart.resize());
-      resizeObserver.observe(performanceHeatmapRef.current);
-
-      return () => {
-        resizeObserver.disconnect();
-        chart.dispose();
-      };
-    }
-  }, [stats, heatmapData, usingSimulatedData, username]);
-
-  // Character Performance bar chart (win rate + usage per character)
-  useEffect(() => {
-    if (!stats || !characterChartRef.current) return;
-
-    const chart = echarts.init(characterChartRef.current);
-
-    const playerColor = username === 'Shayne' ? '#fe8019' : '#b8bb26';
-    const barLabel = {
-      show: true,
-      position: 'top' as const,
-      color: '#a89984',
-      fontSize: 9,
-      formatter: (params: any) => `${Number(params.value).toFixed(0)}%`
-    };
-
-    chart.setOption({
-      backgroundColor: 'transparent',
-      legend: {
-        top: 0,
-        textStyle: { color: '#ebdbb2', fontSize: 11 },
-        itemWidth: 12,
-        itemHeight: 12,
-        itemGap: 10
-      },
-      tooltip: {
-        trigger: 'axis',
-        axisPointer: { type: 'shadow' },
-        backgroundColor: '#3c3836',
-        borderColor: '#504945',
-        borderWidth: 1,
-        padding: 10,
-        textStyle: { color: '#ebdbb2', fontSize: 11 },
-        formatter: (params: any) => {
-          const lines = [`<strong>${params[0].name}</strong>`];
-          params.forEach((p: any) => {
-            const label = p.seriesName === 'Games Played'
-              ? `Usage: ${Number(p.value).toFixed(1)}%`
-              : `Win Rate: ${Number(p.value).toFixed(1)}%`;
-            lines.push(`${p.marker} ${label}`);
-          });
-          return lines.join('<br/>');
-        }
-      },
-      grid: { left: '3%', right: '3%', top: 40, bottom: '3%', containLabel: true },
-      xAxis: {
-        type: 'category',
-        data: stats.characterStats.map(stat => stat.character),
-        axisLine: { lineStyle: { color: '#504945' } },
-        axisTick: { show: false },
-        axisLabel: { color: '#a89984', fontSize: 10, rotate: 45 }
-      },
-      yAxis: {
-        type: 'value',
-        min: 0,
-        max: 100,
-        axisLine: { show: false },
-        axisLabel: { color: '#a89984', fontSize: 10, formatter: '{value}%' },
-        splitLine: { lineStyle: { color: '#3c3836', width: 0.5 } }
-      },
-      series: [
-        {
-          name: 'Win Rate (%)',
-          type: 'bar',
-          data: stats.characterStats.map(stat => stat.winRate),
-          itemStyle: { color: playerColor, borderColor: '#282828', borderWidth: 1 },
-          label: barLabel
-        },
-        {
-          name: 'Games Played',
-          type: 'bar',
-          data: stats.characterStats.map(stat => (stat.totalGames / stats.totalGames) * 100),
-          itemStyle: { color: '#83a598', borderColor: '#282828', borderWidth: 1 },
-          label: barLabel
-        }
-      ]
-    });
-
-    const resizeObserver = new ResizeObserver(() => chart.resize());
-    resizeObserver.observe(characterChartRef.current);
-
-    return () => {
-      resizeObserver.disconnect();
-      chart.dispose();
-    };
-  }, [stats, username]);
-
   // Early returns after all hooks
   if (loading) return <LoadingState label="Loading stats..." />;
   if (error) return <ErrorState message={error} onRetry={fetchStats} />;
@@ -556,6 +271,38 @@ export const UserStats: React.FC = () => {
   const openPlayerTearsheet = () => {
     window.open(`/player-tearsheet?username=${username}`, '_blank');
   };
+
+  // Chart data — dither-kit rows
+  const playerColor: DitherColor = username === 'Shayne' ? 'orange' : 'green';
+
+  const timelineRows: TimelineRow[] =
+    timelineData && !usingSimulatedTimeline
+      ? timelineData.game_numbers.map((n, i) => ({
+          game: `${n}`,
+          label: timelineData.date_ranges?.[i] ?? `Window ${n}`,
+          winRate: timelineData.win_rates[i],
+        }))
+      : buildSimulatedTimeline(
+          (username?.charCodeAt(0) || 0) * 1000,
+          stats.totalGames,
+          stats.overallWinRate
+        );
+
+  const heatmapCells: DitherHeatmapCell[] =
+    heatmapData && !usingSimulatedData
+      ? heatmapData.map(point => ({
+          day: point.day,
+          hour: point.hour,
+          winRate: point.game_count === 0 ? null : point.win_rate,
+          games: point.game_count,
+        }))
+      : buildSimulatedHeatmapCells(username.charCodeAt(0) * 1000);
+
+  const characterRows: CharacterRow[] = stats.characterStats.map(stat => ({
+    character: stat.character,
+    winRate: stat.winRate,
+    usage: stats.totalGames > 0 ? (stat.totalGames / stats.totalGames) * 100 : 0,
+  }));
 
   return (
     <div className={styles['stats-container']}>
@@ -665,7 +412,22 @@ export const UserStats: React.FC = () => {
               </span>
             )}
           </h3>
-          <div ref={winRateTimelineRef} style={{ height: '220px', width: '100%' }}></div>
+          <div style={{ height: '220px', width: '100%' }}>
+            <LineChart
+              data={timelineRows}
+              config={{ winRate: { label: '20-Game Win Rate', color: playerColor } }}
+            >
+              <XAxis dataKey="game" />
+              <YAxis tickFormatter={(value) => `${value}%`} />
+              <Tooltip
+                labelKey="label"
+                valueFormatter={(value) => `${value.toFixed(1)}%`}
+              />
+              <Line dataKey="winRate" variant="gradient">
+                <ActiveDot variant="colored-border" />
+              </Line>
+            </LineChart>
+          </div>
         </div>
         <div className="card" style={{ padding: '1rem' }}>
           <h3 style={{ fontSize: '1rem', marginBottom: '0.5rem', color: '#fbf1c7' }}>
@@ -677,10 +439,12 @@ export const UserStats: React.FC = () => {
             )}
           </h3>
           <div style={{ fontSize: '0.7rem', color: '#a89984', marginBottom: '0.5rem', display: 'flex', gap: '1rem', justifyContent: 'center', flexWrap: 'wrap' }}>
-            <span>Color = Win Rate (🔴 Low → 🟡 Mid → 🟢 High)</span>
-            <span>Brightness = Games Played (Darker = Fewer, Brighter = More)</span>
+            <span>Color = Win Rate (🔴 Low → 🟢 High)</span>
+            <span>Density = Games Played (Sparser = Fewer, Denser = More)</span>
           </div>
-          <div ref={performanceHeatmapRef} style={{ height: '260px', width: '100%' }}></div>
+          <div style={{ width: '100%' }}>
+            <DitherHeatmap cells={heatmapCells} height={260} metricLabel="win rate" />
+          </div>
           
           {/* Character Filter */}
           {stats && stats.characterStats && stats.characterStats.length > 0 && (
@@ -752,7 +516,23 @@ export const UserStats: React.FC = () => {
         <div className="card" style={{ padding: '1rem' }}>
           <h2 style={{ fontSize: '1.1rem', marginBottom: '0.75rem' }}>👊 Character Performance</h2>
           <div style={{ height: '280px', marginBottom: '0.75rem' }}>
-            <div ref={characterChartRef} style={{ width: '100%', height: '100%' }} />
+            <BarChart
+              data={characterRows}
+              config={{
+                winRate: { label: 'Win Rate (%)', color: playerColor },
+                usage: { label: 'Usage (%)', color: 'blue' },
+              }}
+            >
+              <XAxis dataKey="character" />
+              <YAxis tickFormatter={(value) => `${value}%`} />
+              <Legend />
+              <Tooltip
+                labelKey="character"
+                valueFormatter={(value) => `${value.toFixed(1)}%`}
+              />
+              <Bar dataKey="winRate" variant="gradient" />
+              <Bar dataKey="usage" variant="gradient" />
+            </BarChart>
           </div>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '0.5rem' }}>
             {stats.characterStats.slice(0, 4).map((stat) => (


### PR DESCRIPTION
## Summary

Full deployment of [dither-kit](https://www.tripwire.sh/dither-kit) — no pilot. All 14 chart mounts across 8 pages now render through a vendored, Gruvbox-tuned copy of the dithered canvas engine, and **ECharts is removed entirely** (−1,748 lines of chart config; total JS ~1.6 MB → ~0.8 MB).

> **Stacked on #3** (match editor) because both touch SessionDetail — merge #3 first; GitHub retargets this to `main` automatically.

## How it's integrated

- **Vendored, not installed**: `src/components/dither/` from [Boring-Software-Inc/dither-kit](https://github.com/Boring-Software-Inc/dither-kit) (**MIT**, upstream commit `9fb0b14`), with the Evil Charts aesthetic credit upstream requests. The kit expects Tailwind + shadcn; this app has neither, so the ~25 Tailwind utilities it uses are redefined in a scoped `dither.css` under `.dither-root` (Gruvbox values, zero leakage into app CSS) and `cn()` drops tailwind-merge. Minimal source diff → future upstream syncs stay easy.
- **Palette retuned to Gruvbox seeds**: orange = Shayne `#fe8019`, green = Matt `#b8bb26`, blue neutral, new yellow/aqua seeds. Config colors are semantic names, so every chart is in-theme automatically.
- **`DitherHeatmap` (local extension)**: dither-kit has no heatmap, so the three day×hour heatmaps use a ~170-line component built on the kit's own Bayer-matrix primitives — win rate dithers red→green, game count drives density, tooltip chrome matches the kit. Clearly marked non-upstream.
- New deps: `motion`, `d3-scale`, `d3-shape`, `clsx`. Removed: `echarts`.

## Conversion calls worth reviewing

| Chart | Call |
|---|---|
| SessionHistory activity | Rolling-average "trend" line was derived data → replaced with a **stacked Shayne/Matt win-split bar** (total height still = games played, and the win split the old tooltip buried is now visible) |
| Win-rate-bucket colored bars | Per-bar red/orange/green bucketing → single blue series (dither series are one color; the rate is in the tooltip) |
| CharacterDetail matchup bars | Horizontal → vertical (kit is vertical-only); full names in tooltips |
| CharacterDetail usage timeline | bar+line combo → two-line chart (games aqua, trend yellow dashed) |
| Timeline markLines (50% / average) | Dropped — no primitive; overall WR remains in page headers |
| Bug fixed en route | Characters at exactly 100% win rate were silently dropped from the distribution (strict `< 100` last bin) — now inclusive |

## Bundle

| | before | after |
|---|---|---|
| echarts lazy chunk | 1,128 kB | **gone** |
| entry chunk | 280 kB (95 gz) | 461 kB (157 gz) — homepage donut pulls the engine + motion eagerly |
| total JS | ~1.6 MB | **~0.8 MB** |

## Verification

- [x] `tsc` clean · lint 0 errors (31 warnings, fewer than before — two `any`s got typed away) · `vite build` passes · `grep echarts src/` empty
- [x] 12/12 backend tests still pass (untouched)
- [ ] **Reviewer — visual QA is the real test here** (canvas output can't be asserted in CI): click through Home donut, Statistics, both player pages (timeline + heatmap + character bars), Character Analytics/Detail, Sessions history/detail. Check hover tooltips, legend toggles, and phone width.

Rollback note: single revert of this branch restores ECharts wholesale — conversions are page-local with no data-layer changes.