### PR TITLE
feat: reskin interior platform pages to the redesign language

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,17 @@ flowchart LR
   recorded in an audit log (`edit_log.csv`)
 - **Session tracking**: games auto-group into sessions (a 4+ hour gap starts a
   new one)
-- **Statistics dashboard**: win rates, streaks, monthly activity, top matchups,
-  head-to-head breakdown, advanced metrics, matchup matrix
+- **Statistics dashboard**: H2H hero, win rates, streaks, recent form, advanced
+  metrics, top characters/matchups, games-by-month, plus a day/time performance
+  heatmap and stage win-rate breakdown
 - **Per-player stats**: win-rate timelines, day/hour performance heatmaps,
   character and stage stats, tearsheets
-- **Character analytics**: per-character win rates, matchup performance, stage
-  performance, and a usage overview / tier list
-- **Session history**: browse sessions, session detail views, session comparison
+- **Character analytics**: roster ranked by win rate with S/A/B/C tier badges,
+  win-rate distribution, per-character matchup/stage detail
+- **Session history**: browse sessions, session detail views, session comparison,
+  and a shareable PNG session tearsheet (html2canvas export)
+- **Consistent design language**: every interior page shares the redesign's shell,
+  type system, and dither-kit charts (shared primitives in `components/ui.tsx`)
 - **Local CSV storage**: timestamped entries with an automatic backup on each boot
 - **Dark UI**: Gruvbox palette, elevated with a Space Grotesk / IBM Plex Mono type
   system; responsive shell (desktop sidebar / mobile bottom-tabs + drawer)
@@ -156,6 +160,7 @@ frontend/src/
   StatsPage / Session*  # dashboards, session views, tearsheets
   CharacterAnalytics/Detail.tsx
   components/shell/     # AppShell (sidebar / bottom-tabs + drawer), nav icons
+  components/ui.tsx     # shared page primitives (PageColumn, Card, StatTile, TierBadge…)
   components/           # CharacterDisplay, PerformanceHeatmap, Feedback, dither/, stats/
 docs/DEPLOY.md          # Fly.io runbook
 docs/ROADMAP.md         # public-launch roadmap

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -162,6 +162,22 @@ elevated with a Space Grotesk / IBM Plex Mono type system.
   sticky stage in one tap. **Empty states** for new sessions shipped (desktop +
   mobile).
 
+**Interior-page reskin SHIPPED 2026-07-14** (second design handoff): the five
+interior pages were rebuilt in the redesign's visual language, reusing a set of
+shared page primitives (`components/ui.tsx`: PageColumn, PageHeader, SectionTitle,
+Card, GlowPanel, StatTile, TierBadge). Data wiring preserved throughout.
+- **Statistics** (`/stats`): H2H hero (dither donut), quick tiles, rolling
+  win-rate area chart, character win-rate bars, recent form, advanced metrics
+  (tooltips kept), streak records, top characters/matchups, games-by-month bar,
+  and two new widgets — a day/time `DitherHeatmap` and stage win-rate bars (wired
+  to existing `/api/users/<u>/heatmap` and `/stats` routes; no new backend).
+- **Character Analytics** (`/characters`): highest-win-rate callout, distribution
+  + usage bar charts, roster grid ranked by win rate with real icons and S/A/B/C
+  tier badges linking to detail.
+- **Session History / Detail / Tearsheet**: re-skinned; the tearsheet keeps its
+  `html2canvas` PNG export (literal hex inside the captured card so the artifact
+  is theme-independent — verified end-to-end).
+
 Remaining UX backlog, ordered by leverage-per-effort:
 
 1. **Theme via CSS variables**: replace inline hex with the Gruvbox vars in
@@ -169,10 +185,8 @@ Remaining UX backlog, ordered by leverage-per-effort:
    tokens but kept many inline). Unblocks LAUNCH.md's theme-switcher question and
    arbitrary player colors (P3 needs non-Shayne/Matt colors).
 2. **Extend the typed API layer** to the older stats/tearsheet pages and clear
-   the ~30 remaining `no-explicit-any` warnings, then re-promote that ESLint rule
+   the remaining `no-explicit-any` warnings, then re-promote that ESLint rule
    to `error` (`frontend/eslint.config.js`).
-3. **Interior-page reskin**: Statistics / Characters / Sessions / Tearsheets were
-   re-framed into the new shell but keep their pre-redesign internals.
 
 ## 5. Dither-kit adoption — SHIPPED 2026-07-14
 

--- a/frontend/src/CharacterAnalytics.tsx
+++ b/frontend/src/CharacterAnalytics.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import CharacterDisplay from './components/CharacterDisplay';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, type ChartConfig } from './components/dither';
+import { LoadingState, ErrorState } from './components/Feedback';
+import { PageColumn, PageHeader, SectionTitle, Card, TierBadge, winRateTier } from './components/ui';
+import CharToken from './session/components/CharToken';
+import type { Player } from './types';
 
 interface CharacterOverviewData {
   total_games: number;
@@ -34,6 +37,8 @@ interface WinRateBinRow {
   count: number;
 }
 
+// win_rate is a PERCENT (0-100): the bins compare directly against it and it is
+// rendered with a trailing "%". winRateTier() also expects a percent.
 const WIN_RATE_BINS = [0, 20, 40, 50, 60, 80, 100];
 const WIN_RATE_BIN_LABELS = ['0-20%', '20-40%', '40-50%', '50-60%', '60-80%', '80-100%'];
 
@@ -45,32 +50,38 @@ const winRateDistConfig: ChartConfig = {
   count: { label: 'Characters', color: 'blue' },
 };
 
+/** Whoever uses this character more sets its token color. */
+const dominantPlayer = (stats: CharacterOverviewData): Player =>
+  stats.shayne_usage >= stats.matt_usage ? 'Shayne' : 'Matt';
+
 const CharacterAnalytics: React.FC = () => {
   const [data, setData] = useState<CharactersStatsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [sortBy, setSortBy] = useState<'usage_rate' | 'win_rate' | 'total_games'>('usage_rate');
+  const [sortBy, setSortBy] = useState<'usage_rate' | 'win_rate' | 'total_games'>('win_rate');
   const [filterMinGames, setFilterMinGames] = useState(0);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await fetch('/api/characters/overview');
-        const result = await response.json();
-        if (result.success) {
-          setData(result);
-        } else {
-          setError(result.message || 'Failed to load character data');
-        }
-      } catch {
-        setError('Failed to fetch character analytics');
-      } finally {
-        setLoading(false);
+  const fetchData = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/characters/overview');
+      const result = await response.json();
+      if (result.success) {
+        setData(result);
+      } else {
+        setError(result.message || 'Failed to load character data');
       }
-    };
-
-    fetchData();
+    } catch {
+      setError('Failed to fetch character analytics');
+    } finally {
+      setLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
 
   // Top 15 characters by usage rate
   const usageChartData: UsageChartRow[] = data
@@ -100,414 +111,222 @@ const CharacterAnalytics: React.FC = () => {
       }))
     : [];
 
-  if (loading) {
-    return (
-      <div className="stats-container" style={{ 
-        minHeight: '100vh',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center'
-      }}>
-        <div style={{ 
-          textAlign: 'center', 
-          padding: '3rem', 
-          fontSize: '1.2rem',
-          color: '#a89984'
-        }}>
-          Loading character analytics...
-        </div>
-      </div>
-    );
-  }
-  
-  if (error) {
-    return (
-      <div className="stats-container" style={{ 
-        minHeight: '100vh',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center'
-      }}>
-        <div style={{ 
-          textAlign: 'center', 
-          padding: '2rem',
-          fontSize: '1.2rem',
-          color: '#fb4934'
-        }}>
-          {error}
-        </div>
-      </div>
-    );
-  }
-  
+  if (loading) return <LoadingState label="Loading character analytics…" />;
+  if (error) return <ErrorState message={error} onRetry={fetchData} />;
   if (!data) return null;
 
-  // Sort characters based on selected criteria
-  const sortedCharacters = Object.entries(data.characters).sort((a, b) => {
-    const aVal = a[1][sortBy];
-    const bVal = b[1][sortBy];
-    return bVal - aVal;
-  });
+  const charactersWithData = Object.entries(data.characters).filter(
+    ([, stats]) => stats.total_games > 0
+  );
 
-  // Filter characters with at least some usage and minimum games
-  const activeCharacters = sortedCharacters.filter(([_, stats]) => stats.total_games >= filterMinGames);
+  // Highest win rate among characters with a meaningful sample (>= 20 games).
+  const winRateLeader = charactersWithData
+    .filter(([, stats]) => stats.total_games >= 20)
+    .sort((a, b) => b[1].win_rate - a[1].win_rate)[0];
+
+  // Sort characters based on selected criteria, then filter by minimum games.
+  const sortedCharacters = Object.entries(data.characters).sort(
+    (a, b) => b[1][sortBy] - a[1][sortBy]
+  );
+  const activeCharacters = sortedCharacters.filter(
+    ([, stats]) => stats.total_games >= filterMinGames
+  );
+
+  const sortOptions: Array<{ key: typeof sortBy; label: string }> = [
+    { key: 'usage_rate', label: 'Usage' },
+    { key: 'win_rate', label: 'Win rate' },
+    { key: 'total_games', label: 'Games' },
+  ];
 
   return (
-    <div className="stats-container" style={{ 
-      maxWidth: '1400px', 
-      padding: '1.5rem',
-      margin: '0 auto'
-    }}>
-      {/* Header Section */}
-      <section className="stats-section" style={{ marginBottom: '1.5rem' }}>
-        <div style={{
-          background: 'linear-gradient(135deg, #3c3836 0%, #282828 100%)',
-          borderRadius: '16px',
-          padding: '1.5rem',
-          border: '1px solid #504945',
-          boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
-          textAlign: 'center'
-        }}>
-          <h1 style={{ 
-            fontSize: '1.8rem', 
-            fontWeight: 'bold',
-            marginBottom: '0.5rem',
-            color: '#fbf1c7'
-          }}>
-            🎮 Character Analytics
-          </h1>
-          <p style={{ 
-            color: '#a89984', 
-            marginBottom: '1rem', 
-            fontSize: '0.9rem' 
-          }}>
-            {data.total_matches} total matches • {activeCharacters.length} characters with data
-          </p>
-          
-          {/* Quick Stats */}
-          <div style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))',
-            gap: '1rem',
-            marginTop: '1rem'
-          }}>
-            <div>
-              <div style={{ fontSize: '0.7rem', color: '#a89984', marginBottom: '0.25rem', textTransform: 'uppercase' }}>
-                Most Used
-              </div>
-              <div style={{ fontSize: '1.2rem', fontWeight: 'bold', color: '#83a598' }}>
-                {activeCharacters[0] ? activeCharacters[0][0] : 'N/A'}
-              </div>
-              <div style={{ fontSize: '0.7rem', color: '#a89984' }}>
-                {activeCharacters[0] ? `${activeCharacters[0][1].usage_rate}%` : ''}
-              </div>
-            </div>
-            <div>
-              <div style={{ fontSize: '0.7rem', color: '#a89984', marginBottom: '0.25rem', textTransform: 'uppercase' }}>
-                Highest Win Rate
-              </div>
-              <div style={{ fontSize: '1.2rem', fontWeight: 'bold', color: '#b8bb26' }}>
-                {sortedCharacters.filter(([_, s]) => s.total_games >= 20)[0] ? 
-                  sortedCharacters.filter(([_, s]) => s.total_games >= 20).sort((a, b) => b[1].win_rate - a[1].win_rate)[0][0] : 'N/A'}
-              </div>
-              <div style={{ fontSize: '0.7rem', color: '#a89984' }}>
-                {sortedCharacters.filter(([_, s]) => s.total_games >= 20)[0] ? 
-                  `${sortedCharacters.filter(([_, s]) => s.total_games >= 20).sort((a, b) => b[1].win_rate - a[1].win_rate)[0][1].win_rate}%` : ''}
-              </div>
-            </div>
-            <div>
-              <div style={{ fontSize: '0.7rem', color: '#a89984', marginBottom: '0.25rem', textTransform: 'uppercase' }}>
-                Active Roster
-              </div>
-              <div style={{ fontSize: '1.2rem', fontWeight: 'bold', color: '#fabd2f' }}>
-                {activeCharacters.length}
-              </div>
-              <div style={{ fontSize: '0.7rem', color: '#a89984' }}>
-                characters
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
+    <PageColumn>
+      <PageHeader
+        title="Character Analytics"
+        subtitle={`${data.total_matches.toLocaleString()} total matches · ${charactersWithData.length} characters with data`}
+      />
 
-      <section className="stats-section">
-
-        {/* Visualizations */}
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(400px, 1fr))', gap: '1rem', marginBottom: '1rem' }}>
-          <div className="card" style={{ padding: '1rem' }}>
-            <h3 style={{ fontSize: '1rem', marginBottom: '0.75rem', color: '#fbf1c7' }}>📊 Top 15 by Usage</h3>
-            <div style={{ height: '220px', width: '100%' }}>
-              <BarChart data={usageChartData} config={usageChartConfig}>
-                <XAxis dataKey="name" tickFormatter={(value) => String(value).split(' ')[0]} />
-                <YAxis tickFormatter={(value) => `${value}%`} />
-                <Tooltip labelKey="name" />
-                <Bar dataKey="usage" variant="gradient" />
-              </BarChart>
-            </div>
+      {/* Highest win rate callout + win-rate distribution */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(320px,1fr))', gap: 20 }}>
+        <div
+          style={{
+            background: 'linear-gradient(135deg,#2a1c0e,#1f1712)',
+            border: '1px solid #5a3410',
+            borderRadius: 18,
+            padding: 22,
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+          }}
+        >
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--shayne)', letterSpacing: 1, marginBottom: 10 }}>
+            🏆 HIGHEST WIN RATE
           </div>
-          <div className="card" style={{ padding: '1rem' }}>
-            <h3 style={{ fontSize: '1rem', marginBottom: '0.75rem', color: '#fbf1c7' }}>📈 Win Rate Distribution</h3>
-            <div style={{ height: '220px', width: '100%' }}>
-              <BarChart data={winRateDistData} config={winRateDistConfig}>
-                <XAxis dataKey="range" />
-                <YAxis />
-                <Tooltip labelKey="range" />
-                <Bar dataKey="count" variant="gradient" />
-              </BarChart>
+          {winRateLeader ? (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+              <CharToken
+                character={winRateLeader[0]}
+                player={dominantPlayer(winRateLeader[1])}
+                size={54}
+                radius={15}
+              />
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontSize: 20, fontWeight: 700, color: 'var(--fg-light)' }}>{winRateLeader[0]}</div>
+                <div style={{ fontSize: 12, color: 'var(--gray)', fontFamily: 'var(--font-mono)', marginTop: 2 }}>
+                  {dominantPlayer(winRateLeader[1])} · {winRateLeader[1].total_games} games
+                </div>
+              </div>
+              <div style={{ marginLeft: 'auto', fontFamily: 'var(--font-mono)', fontSize: 34, fontWeight: 700, color: 'var(--shayne)' }}>
+                {winRateLeader[1].win_rate}%
+              </div>
             </div>
-          </div>
+          ) : (
+            <div style={{ fontSize: 13, color: 'var(--gray)' }}>Not enough games yet (min 20).</div>
+          )}
         </div>
 
-        {/* Controls */}
-        <div style={{ 
-          display: 'flex', 
+        <Card>
+          <SectionTitle>Win rate distribution</SectionTitle>
+          <div style={{ width: '100%', height: 200 }}>
+            <BarChart data={winRateDistData} config={winRateDistConfig}>
+              <XAxis dataKey="range" />
+              <YAxis />
+              <Tooltip labelKey="range" />
+              <Bar dataKey="count" variant="gradient" />
+            </BarChart>
+          </div>
+        </Card>
+      </div>
+
+      {/* Top 15 by usage */}
+      <Card>
+        <SectionTitle>Top 15 by usage</SectionTitle>
+        <div style={{ width: '100%', height: 240 }}>
+          <BarChart data={usageChartData} config={usageChartConfig}>
+            <XAxis dataKey="name" tickFormatter={(value) => String(value).split(' ')[0]} />
+            <YAxis tickFormatter={(value) => `${value}%`} />
+            <Tooltip labelKey="name" />
+            <Bar dataKey="usage" variant="gradient" />
+          </BarChart>
+        </div>
+      </Card>
+
+      {/* Controls */}
+      <div
+        style={{
+          display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
-          gap: '1rem', 
-          marginBottom: '1.5rem',
+          gap: 12,
           flexWrap: 'wrap',
-          background: '#3c3836',
-          padding: '1rem',
-          borderRadius: '12px',
-          border: '1px solid #504945',
-          boxShadow: '0 2px 8px rgba(0,0,0,0.2)'
-        }}>
-          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
-            <span style={{ fontSize: '0.8rem', color: '#a89984', marginRight: '0.5rem', fontWeight: '600' }}>
-              Sort by:
-            </span>
-            <button
-              onClick={() => setSortBy('usage_rate')}
-              style={{
-                padding: '0.5rem 1rem',
-                fontSize: '0.85rem',
-                borderRadius: '8px',
-                border: sortBy === 'usage_rate' ? '2px solid #83a598' : '1px solid #504945',
-                background: sortBy === 'usage_rate' ? '#83a598' : '#282828',
-                color: sortBy === 'usage_rate' ? '#282828' : '#ebdbb2',
-                cursor: 'pointer',
-                transition: 'all 0.2s',
-                fontWeight: sortBy === 'usage_rate' ? 'bold' : 'normal'
-              }}
-              onMouseEnter={(e) => {
-                if (sortBy !== 'usage_rate') e.currentTarget.style.background = '#3c3836';
-              }}
-              onMouseLeave={(e) => {
-                if (sortBy !== 'usage_rate') e.currentTarget.style.background = '#282828';
-              }}
-            >
-              📊 Usage
-            </button>
-            <button
-              onClick={() => setSortBy('win_rate')}
-              style={{
-                padding: '0.5rem 1rem',
-                fontSize: '0.85rem',
-                borderRadius: '8px',
-                border: sortBy === 'win_rate' ? '2px solid #83a598' : '1px solid #504945',
-                background: sortBy === 'win_rate' ? '#83a598' : '#282828',
-                color: sortBy === 'win_rate' ? '#282828' : '#ebdbb2',
-                cursor: 'pointer',
-                transition: 'all 0.2s',
-                fontWeight: sortBy === 'win_rate' ? 'bold' : 'normal'
-              }}
-              onMouseEnter={(e) => {
-                if (sortBy !== 'win_rate') e.currentTarget.style.background = '#3c3836';
-              }}
-              onMouseLeave={(e) => {
-                if (sortBy !== 'win_rate') e.currentTarget.style.background = '#282828';
-              }}
-            >
-              🏆 Win Rate
-            </button>
-            <button
-              onClick={() => setSortBy('total_games')}
-              style={{
-                padding: '0.5rem 1rem',
-                fontSize: '0.85rem',
-                borderRadius: '8px',
-                border: sortBy === 'total_games' ? '2px solid #83a598' : '1px solid #504945',
-                background: sortBy === 'total_games' ? '#83a598' : '#282828',
-                color: sortBy === 'total_games' ? '#282828' : '#ebdbb2',
-                cursor: 'pointer',
-                transition: 'all 0.2s',
-                fontWeight: sortBy === 'total_games' ? 'bold' : 'normal'
-              }}
-              onMouseEnter={(e) => {
-                if (sortBy !== 'total_games') e.currentTarget.style.background = '#3c3836';
-              }}
-              onMouseLeave={(e) => {
-                if (sortBy !== 'total_games') e.currentTarget.style.background = '#282828';
-              }}
-            >
-              🎮 Games
-            </button>
-          </div>
-          
-          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
-            <label style={{ fontSize: '0.8rem', color: '#a89984', fontWeight: '600' }}>
-              Min Games:
-            </label>
-            <select 
-              value={filterMinGames} 
-              onChange={(e) => setFilterMinGames(Number(e.target.value))}
-              style={{
-                padding: '0.5rem 0.75rem',
-                fontSize: '0.85rem',
-                borderRadius: '8px',
-                border: '1px solid #504945',
-                background: '#282828',
-                color: '#ebdbb2',
-                cursor: 'pointer',
-                fontWeight: '500',
-                transition: 'all 0.2s'
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.background = '#3c3836';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.background = '#282828';
-              }}
-            >
-              <option value={0}>All Characters</option>
-              <option value={5}>5+ games</option>
-              <option value={10}>10+ games</option>
-              <option value={20}>20+ games</option>
-              <option value={50}>50+ games</option>
-            </select>
-          </div>
+          background: 'var(--panel)',
+          border: '1px solid var(--line-2)',
+          borderRadius: 14,
+          padding: '12px 16px',
+        }}
+      >
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--gray)', letterSpacing: '0.5px' }}>
+            SORT
+          </span>
+          {sortOptions.map((opt) => {
+            const active = sortBy === opt.key;
+            return (
+              <button
+                key={opt.key}
+                onClick={() => setSortBy(opt.key)}
+                style={{
+                  padding: '6px 14px',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  borderRadius: 999,
+                  border: `1px solid ${active ? 'var(--shayne)' : 'var(--line-2)'}`,
+                  background: active ? 'var(--shayne)' : 'var(--card)',
+                  color: active ? 'var(--deep1)' : 'var(--fg)',
+                  cursor: 'pointer',
+                  transition: 'all 0.15s',
+                  fontFamily: 'var(--font-display)',
+                }}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
         </div>
 
-        {/* Character Grid */}
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))',
-          gap: '1rem'
-        }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--gray)', letterSpacing: '0.5px' }}>
+            MIN GAMES
+          </span>
+          <select
+            value={filterMinGames}
+            onChange={(e) => setFilterMinGames(Number(e.target.value))}
+            style={{
+              padding: '6px 10px',
+              fontSize: 12,
+              borderRadius: 8,
+              border: '1px solid var(--line-2)',
+              background: 'var(--card)',
+              color: 'var(--fg)',
+              cursor: 'pointer',
+              fontFamily: 'var(--font-mono)',
+            }}
+          >
+            <option value={0}>All</option>
+            <option value={5}>5+</option>
+            <option value={10}>10+</option>
+            <option value={20}>20+</option>
+            <option value={50}>50+</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Roster */}
+      <div>
+        <SectionTitle>Roster — ranked by win rate</SectionTitle>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(280px,1fr))', gap: 14 }}>
           {activeCharacters.map(([character, stats]) => (
             <Link
               key={character}
               to={`/characters/${encodeURIComponent(character)}`}
               style={{
+                background: 'var(--panel)',
+                border: '1px solid var(--line-2)',
+                borderRadius: 16,
+                padding: 16,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 14,
+                cursor: 'pointer',
                 textDecoration: 'none',
-                background: '#3c3836',
-                borderRadius: '12px',
-                padding: '1rem',
-                border: '1px solid #504945',
-                transition: 'all 0.2s',
-                display: 'block',
-                boxShadow: '0 2px 4px rgba(0,0,0,0.2)'
-              }}
-              onMouseOver={(e) => {
-                e.currentTarget.style.transform = 'translateY(-4px)';
-                e.currentTarget.style.boxShadow = '0 6px 16px rgba(0, 0, 0, 0.4)';
-                e.currentTarget.style.borderColor = '#83a598';
-              }}
-              onMouseOut={(e) => {
-                e.currentTarget.style.transform = 'none';
-                e.currentTarget.style.boxShadow = '0 2px 4px rgba(0,0,0,0.2)';
-                e.currentTarget.style.borderColor = '#504945';
               }}
             >
-              <div style={{ 
-                display: 'flex', 
-                alignItems: 'center', 
-                gap: '0.75rem', 
-                marginBottom: '0.75rem',
-                paddingBottom: '0.75rem',
-                borderBottom: '1px solid #504945'
-              }}>
-                <CharacterDisplay character={character} hideText={false} />
-              </div>
-
-              <div style={{ 
-                display: 'grid', 
-                gridTemplateColumns: '1fr 1fr', 
-                gap: '0.75rem', 
-                marginBottom: '0.75rem' 
-              }}>
-                <div style={{
-                  background: '#282828',
-                  padding: '0.5rem',
-                  borderRadius: '6px',
-                  border: '1px solid #3c3836'
-                }}>
-                  <div style={{ fontSize: '0.7rem', color: '#a89984', marginBottom: '0.25rem' }}>
-                    Usage
-                  </div>
-                  <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#83a598' }}>
-                    {stats.usage_rate}%
-                  </div>
+              <CharToken character={character} player={dominantPlayer(stats)} size={46} radius={13} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ fontSize: 15, fontWeight: 700, color: 'var(--fg-light)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                    {character}
+                  </span>
+                  <TierBadge tier={winRateTier(stats.win_rate)} />
                 </div>
-                <div style={{
-                  background: '#282828',
-                  padding: '0.5rem',
-                  borderRadius: '6px',
-                  border: '1px solid #3c3836'
-                }}>
-                  <div style={{ fontSize: '0.7rem', color: '#a89984', marginBottom: '0.25rem' }}>
-                    Win Rate
-                  </div>
-                  <div style={{ 
-                    fontSize: '1.1rem', 
-                    fontWeight: 'bold', 
-                    color: stats.win_rate >= 50 ? '#b8bb26' : '#fb4934' 
-                  }}>
-                    {stats.win_rate}%
-                  </div>
-                </div>
-                <div style={{
-                  background: '#282828',
-                  padding: '0.5rem',
-                  borderRadius: '6px',
-                  border: '1px solid #3c3836'
-                }}>
-                  <div style={{ fontSize: '0.7rem', color: '#a89984', marginBottom: '0.25rem' }}>
-                    Games
-                  </div>
-                  <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#ebdbb2' }}>
-                    {stats.total_games}
-                  </div>
-                </div>
-                <div style={{
-                  background: '#282828',
-                  padding: '0.5rem',
-                  borderRadius: '6px',
-                  border: '1px solid #3c3836'
-                }}>
-                  <div style={{ fontSize: '0.7rem', color: '#a89984', marginBottom: '0.25rem' }}>
-                    Wins
-                  </div>
-                  <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#ebdbb2' }}>
-                    {stats.wins}
-                  </div>
+                <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--gray)', marginTop: 3 }}>
+                  {stats.total_games} games
                 </div>
               </div>
-
-              <div style={{ 
-                display: 'flex', 
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                fontSize: '0.75rem',
-                background: '#282828',
-                padding: '0.5rem',
-                borderRadius: '6px',
-                border: '1px solid #3c3836'
-              }}>
-                <div>
-                  <span style={{ color: '#a89984', marginRight: '0.25rem' }}>Shayne:</span>
-                  <span style={{ color: '#fe8019', fontWeight: 'bold' }}>{stats.shayne_usage}</span>
-                </div>
-                <div>
-                  <span style={{ color: '#a89984', marginRight: '0.25rem' }}>Matt:</span>
-                  <span style={{ color: '#b8bb26', fontWeight: 'bold' }}>{stats.matt_usage}</span>
-                </div>
+              <div
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 22,
+                  fontWeight: 700,
+                  color: stats.win_rate >= 50 ? 'var(--shayne)' : 'var(--gray)',
+                }}
+              >
+                {stats.win_rate}%
               </div>
             </Link>
           ))}
         </div>
-      </section>
-    </div>
+      </div>
+    </PageColumn>
   );
 };
 

--- a/frontend/src/SessionDetail.tsx
+++ b/frontend/src/SessionDetail.tsx
@@ -5,6 +5,8 @@ import CharacterDisplay from './components/CharacterDisplay';
 import MatchEditorModal, { type EditableMatch } from './components/MatchEditorModal';
 import { LoadingState, ErrorState } from './components/Feedback';
 import { stageImages } from './lib/stages';
+import { PageColumn, SectionTitle, Card, GlowPanel } from './components/ui';
+import { sessionDisplayName, formatDuration, matchTime, stocksLabel } from './session/format';
 
 interface SessionStats {
   success: boolean;
@@ -67,8 +69,8 @@ function SessionDetail() {
       }
 
       setStats(data);
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load session');
     } finally {
       setLoading(false);
     }
@@ -107,37 +109,21 @@ function SessionDetail() {
       ]
     : [];
 
-  const formatDateTime = (dateStr: string) => {
+  const formatTimeOfDay = (dateStr: string) => {
     const date = new Date(dateStr);
-    return date.toLocaleString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit'
-    });
+    return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
   };
 
-  const formatMatchTime = (dateStr: string) => {
+  const formatDatePart = (dateStr: string) => {
     const date = new Date(dateStr);
-    return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
   };
 
-  const formatStocks = (value: EditableMatch['stocks_remaining']): string => {
-    if (value === null || value === undefined || value === '') return '—';
-    return `${value} stk`;
-  };
-
-  const calculateDuration = () => {
-    if (!stats) return '';
+  const durationMinutes = () => {
+    if (!stats) return 0;
     const start = new Date(stats.start_time);
     const end = new Date(stats.end_time);
-    const minutes = Math.floor((end.getTime() - start.getTime()) / 60000);
-    
-    if (minutes < 60) return `${minutes}m`;
-    const hours = Math.floor(minutes / 60);
-    const mins = minutes % 60;
-    return `${hours}h ${mins}m`;
+    return Math.floor((end.getTime() - start.getTime()) / 60000);
   };
 
   const handleGenerateTearsheet = () => {
@@ -153,106 +139,79 @@ function SessionDetail() {
   }
 
   return (
-    <div style={{ padding: '2rem', maxWidth: '1400px', margin: '0 auto' }}>
-      {/* Back Button */}
-      <Link 
+    <PageColumn gap={24}>
+      {/* Back link */}
+      <Link
         to="/sessions"
         style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: '0.5rem',
-          color: '#83a598',
+          fontFamily: 'var(--font-mono)',
+          fontSize: 12,
+          color: 'var(--blue)',
           textDecoration: 'none',
-          marginBottom: '1.5rem',
-          fontSize: '0.9rem'
         }}
       >
         ← Back to Sessions
       </Link>
 
       {/* Header */}
-      <div style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'flex-start',
-        marginBottom: '2rem'
-      }}>
-        <div>
-          <h1 style={{
-            fontSize: '2rem',
-            fontWeight: 'bold',
-            color: '#fbf1c7',
-            marginBottom: '0.5rem'
-          }}>
-            Session Details
-          </h1>
-          <div style={{ color: '#a89984', fontSize: '0.95rem' }}>
-            {formatDateTime(stats.start_time)} → {formatDateTime(stats.end_time)}
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 20, flexWrap: 'wrap' }}>
+        <div style={{ minWidth: 0 }}>
+          <h2 style={{ fontSize: 26, fontWeight: 700, color: 'var(--fg-light)', letterSpacing: '-0.5px', margin: 0, fontFamily: 'var(--font-display)' }}>
+            {sessionDisplayName(stats.start_time)}
+          </h2>
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--gray)', marginTop: 6 }}>
+            {formatDatePart(stats.start_time)} · {formatTimeOfDay(stats.start_time)} → {formatTimeOfDay(stats.end_time)}
           </div>
-          <div style={{ color: '#a89984', fontSize: '0.85rem', marginTop: '0.25rem' }}>
-            Duration: {calculateDuration()}
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--faint)', marginTop: 2 }}>
+            Duration: {formatDuration(durationMinutes())}
           </div>
         </div>
 
         <button
           onClick={handleGenerateTearsheet}
           style={{
-            padding: '0.75rem 1.5rem',
-            background: '#83a598',
-            color: '#282828',
+            background: 'var(--blue)',
             border: 'none',
-            borderRadius: '8px',
-            fontSize: '0.9rem',
-            fontWeight: 'bold',
+            borderRadius: 12,
+            padding: '11px 18px',
+            color: 'var(--deep0)',
+            fontFamily: 'var(--font-display)',
+            fontSize: 13,
+            fontWeight: 700,
             cursor: 'pointer',
-            transition: 'all 0.2s'
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.background = '#a3c0b8';
-            e.currentTarget.style.transform = 'translateY(-1px)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.background = '#83a598';
-            e.currentTarget.style.transform = 'none';
           }}
         >
-          📊 Generate Tearsheet
+          Generate tearsheet
         </button>
       </div>
 
-      {/* Hero Stats */}
-      <div style={{
-        background: 'linear-gradient(135deg, #3c3836 0%, #282828 100%)',
-        borderRadius: '16px',
-        padding: '2rem',
-        marginBottom: '2rem',
-        border: '2px solid #504945'
-      }}>
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: '2rem', alignItems: 'center' }}>
+      {/* Score hero */}
+      <GlowPanel style={{ padding: '28px 32px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 24, flexWrap: 'wrap' }}>
           <div>
-            <div style={{ fontSize: '0.8rem', color: '#a89984', marginBottom: '0.75rem', textTransform: 'uppercase', letterSpacing: '1px' }}>
-              Session Score
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--gray)', letterSpacing: 2, marginBottom: 12 }}>
+              SESSION SCORE
             </div>
-            <div style={{ display: 'flex', gap: '2rem', marginBottom: '0.75rem' }}>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 20 }}>
               <div>
-                <div style={{ fontSize: '2.5rem', fontWeight: 'bold', color: '#fe8019', lineHeight: 1 }}>
+                <div style={{ fontFamily: 'var(--font-mono)', fontSize: 56, fontWeight: 700, color: 'var(--shayne)', lineHeight: 1 }}>
                   {stats.shayne_wins}
                 </div>
-                <div style={{ fontSize: '0.9rem', color: '#a89984', marginTop: '0.25rem' }}>Shayne</div>
+                <div style={{ fontSize: 13, color: 'var(--gray)', marginTop: 4 }}>Shayne</div>
               </div>
-              <div style={{ fontSize: '2rem', color: '#504945', alignSelf: 'center' }}>-</div>
+              <div style={{ fontFamily: 'var(--font-mono)', fontSize: 36, color: 'var(--border-light)' }}>–</div>
               <div>
-                <div style={{ fontSize: '2.5rem', fontWeight: 'bold', color: '#b8bb26', lineHeight: 1 }}>
+                <div style={{ fontFamily: 'var(--font-mono)', fontSize: 56, fontWeight: 700, color: 'var(--matt)', lineHeight: 1 }}>
                   {stats.matt_wins}
                 </div>
-                <div style={{ fontSize: '0.9rem', color: '#a89984', marginTop: '0.25rem' }}>Matt</div>
+                <div style={{ fontSize: 13, color: 'var(--gray)', marginTop: 4 }}>Matt</div>
               </div>
             </div>
-            <div style={{ fontSize: '0.85rem', color: '#a89984' }}>
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--gray)', marginTop: 14 }}>
               {stats.total_games} games played
             </div>
           </div>
-          <div style={{ width: 120, height: 120 }}>
+          <div style={{ width: 116, height: 116, flex: '0 0 auto' }}>
             <PieChart
               data={winSplitData}
               config={{
@@ -267,65 +226,46 @@ function SessionDetail() {
             </PieChart>
           </div>
         </div>
-      </div>
+      </GlowPanel>
 
-      {/* Matchups */}
+      {/* Character matchups */}
       {stats.matchup_stats && stats.matchup_stats.length > 0 && (
-        <div style={{ marginBottom: '2rem' }}>
-          <h3 style={{ fontSize: '1.3rem', marginBottom: '1rem', color: '#fbf1c7', fontWeight: 'bold' }}>
-            Character Matchups
-          </h3>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        <div>
+          <SectionTitle>Character matchups</SectionTitle>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
             {stats.matchup_stats.map((matchup, idx) => (
               <div
                 key={idx}
                 style={{
-                  background: '#3c3836',
-                  borderRadius: '10px',
-                  padding: '1rem',
-                  border: '1px solid #504945',
+                  background: 'var(--panel)',
+                  border: '1px solid var(--line-2)',
+                  borderRadius: 12,
+                  padding: '14px 18px',
                   display: 'flex',
+                  alignItems: 'center',
                   justifyContent: 'space-between',
-                  alignItems: 'center'
+                  gap: 12,
+                  flexWrap: 'wrap',
                 }}
               >
-                <div style={{ flex: 1 }}>
-                  <div style={{
-                    fontSize: '1rem',
-                    fontWeight: 'bold',
-                    marginBottom: '0.5rem',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '0.75rem'
-                  }}>
-                    <span style={{ color: '#fe8019' }}>
-                      <CharacterDisplay character={matchup.shayne_character} />
-                    </span>
-                    <span style={{ color: '#a89984', fontSize: '0.85rem' }}>vs</span>
-                    <span style={{ color: '#b8bb26' }}>
-                      <CharacterDisplay character={matchup.matt_character} />
-                    </span>
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ fontSize: 15, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+                    <span style={{ color: 'var(--shayne)' }}>{matchup.shayne_character}</span>
+                    <span style={{ color: 'var(--faint)', fontSize: 13 }}>vs</span>
+                    <span style={{ color: 'var(--matt)' }}>{matchup.matt_character}</span>
                   </div>
-                  <div style={{ fontSize: '0.75rem', color: '#a89984' }}>
-                    {matchup.total_games} {matchup.total_games === 1 ? 'game' : 'games'}
+                  <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--gray)', marginTop: 3 }}>
+                    {matchup.total_games} games
                   </div>
                 </div>
-                <div style={{
-                  display: 'flex',
-                  gap: '1.5rem',
-                  alignItems: 'center'
-                }}>
-                  <div style={{ textAlign: 'center' }}>
-                    <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#fe8019' }}>
-                      {matchup.shayne_wins}
-                    </div>
-                  </div>
-                  <div style={{ fontSize: '1.2rem', color: '#504945' }}>-</div>
-                  <div style={{ textAlign: 'center' }}>
-                    <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#b8bb26' }}>
-                      {matchup.matt_wins}
-                    </div>
-                  </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 18 }}>
+                  <span style={{ fontFamily: 'var(--font-mono)', fontSize: 22, fontWeight: 700, color: 'var(--shayne)' }}>
+                    {matchup.shayne_wins}
+                  </span>
+                  <span style={{ fontFamily: 'var(--font-mono)', fontSize: 16, color: 'var(--border-light)' }}>–</span>
+                  <span style={{ fontFamily: 'var(--font-mono)', fontSize: 22, fontWeight: 700, color: 'var(--matt)' }}>
+                    {matchup.matt_wins}
+                  </span>
                 </div>
               </div>
             ))}
@@ -333,232 +273,152 @@ function SessionDetail() {
         </div>
       )}
 
-      {/* Character Usage */}
+      {/* Character usage */}
       {(Object.keys(stats.shayne_characters).length > 0 || Object.keys(stats.matt_characters).length > 0) && (
-        <div style={{ marginBottom: '2rem' }}>
-          <h3 style={{ fontSize: '1.3rem', marginBottom: '1rem', color: '#fbf1c7', fontWeight: 'bold' }}>
-            Character Usage
-          </h3>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
-            <div style={{
-              background: '#3c3836',
-              borderRadius: '12px',
-              padding: '1.25rem',
-              border: '1px solid #504945'
-            }}>
-              <div style={{
-                fontSize: '1rem',
-                color: '#fe8019',
-                marginBottom: '1rem',
-                fontWeight: 'bold'
-              }}>
-                Shayne
+        <div>
+          <SectionTitle>Character usage</SectionTitle>
+          <div className="char-usage-grid" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+            {([
+              ['Shayne', stats.shayne_characters, 'var(--shayne)'] as const,
+              ['Matt', stats.matt_characters, 'var(--matt)'] as const,
+            ]).map(([name, chars, color]) => (
+              <div
+                key={name}
+                style={{
+                  background: 'var(--panel)',
+                  border: '1px solid var(--line-2)',
+                  borderRadius: 14,
+                  padding: 18,
+                }}
+              >
+                <div style={{ fontSize: 13, fontWeight: 700, color, marginBottom: 14 }}>{name}</div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 9 }}>
+                  {Object.entries(chars)
+                    .sort(([, a], [, b]) => b - a)
+                    .map(([char, count]) => (
+                      <div
+                        key={char}
+                        style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}
+                      >
+                        <CharacterDisplay character={char} />
+                        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 15, fontWeight: 700, color }}>
+                          {count}
+                        </span>
+                      </div>
+                    ))}
+                </div>
               </div>
-              {Object.entries(stats.shayne_characters)
-                .sort(([, a], [, b]) => b - a)
-                .map(([char, count]) => (
-                  <div
-                    key={char}
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center',
-                      marginBottom: '0.75rem',
-                      padding: '0.5rem',
-                      background: '#282828',
-                      borderRadius: '6px'
-                    }}
-                  >
-                    <div style={{ fontSize: '0.95rem' }}>
-                      <CharacterDisplay character={char} />
-                    </div>
-                    <span style={{
-                      fontSize: '1.1rem',
-                      fontWeight: 'bold',
-                      color: '#fe8019'
-                    }}>
-                      {count}
-                    </span>
-                  </div>
-                ))}
-            </div>
-            <div style={{
-              background: '#3c3836',
-              borderRadius: '12px',
-              padding: '1.25rem',
-              border: '1px solid #504945'
-            }}>
-              <div style={{
-                fontSize: '1rem',
-                color: '#b8bb26',
-                marginBottom: '1rem',
-                fontWeight: 'bold'
-              }}>
-                Matt
-              </div>
-              {Object.entries(stats.matt_characters)
-                .sort(([, a], [, b]) => b - a)
-                .map(([char, count]) => (
-                  <div
-                    key={char}
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center',
-                      marginBottom: '0.75rem',
-                      padding: '0.5rem',
-                      background: '#282828',
-                      borderRadius: '6px'
-                    }}
-                  >
-                    <div style={{ fontSize: '0.95rem' }}>
-                      <CharacterDisplay character={char} />
-                    </div>
-                    <span style={{
-                      fontSize: '1.1rem',
-                      fontWeight: 'bold',
-                      color: '#b8bb26'
-                    }}>
-                      {count}
-                    </span>
-                  </div>
-                ))}
-            </div>
+            ))}
           </div>
+          <style>{`
+            @media (max-width: 640px) {
+              .char-usage-grid { grid-template-columns: 1fr !important; }
+            }
+          `}</style>
         </div>
       )}
 
-      {/* Stage Stats */}
+      {/* Stage breakdown */}
       {stats.stage_stats.length > 0 && (
         <div>
-          <h3 style={{ fontSize: '1.3rem', marginBottom: '1rem', color: '#fbf1c7', fontWeight: 'bold' }}>
-            Stage Breakdown
-          </h3>
-          <div style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
-            gap: '0.75rem'
-          }}>
-            {stats.stage_stats.map(stat => (
-              <div
-                key={stat.stage}
-                style={{
-                  backgroundImage: stageImages[stat.stage] ? `url(${stageImages[stat.stage]})` : 'none',
-                  backgroundSize: 'cover',
-                  backgroundPosition: 'center',
-                  borderRadius: '12px',
-                  padding: '1rem',
-                  minHeight: '100px',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  justifyContent: 'space-between',
-                  position: 'relative',
-                  overflow: 'hidden',
-                  border: '2px solid #504945'
-                }}
-              >
-                <div style={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  right: 0,
-                  bottom: 0,
-                  backgroundColor: 'rgba(0, 0, 0, 0.65)',
-                  zIndex: 1,
-                }} />
-                <div style={{
-                  position: 'relative',
-                  zIndex: 2,
-                  fontSize: '0.9rem',
-                  color: '#fbf1c7',
-                  fontWeight: 'bold',
-                  textShadow: '0 2px 4px rgba(0,0,0,0.9)'
-                }}>
-                  {stat.stage}
+          <SectionTitle>Stage breakdown</SectionTitle>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(140px,1fr))', gap: 12 }}>
+            {stats.stage_stats.map((stat) => {
+              const img = stageImages[stat.stage];
+              return (
+                <div
+                  key={stat.stage}
+                  style={{
+                    position: 'relative',
+                    overflow: 'hidden',
+                    borderRadius: 14,
+                    border: '1px solid var(--line)',
+                    minHeight: 100,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    justifyContent: 'space-between',
+                    padding: 14,
+                  }}
+                >
+                  <div
+                    style={{
+                      position: 'absolute',
+                      inset: 0,
+                      backgroundImage: img
+                        ? `url(${img})`
+                        : 'repeating-linear-gradient(115deg,#2a2624,#2a2624 8px,#302b28 8px,#302b28 16px)',
+                      backgroundSize: 'cover',
+                      backgroundPosition: 'center',
+                    }}
+                  />
+                  <div style={{ position: 'absolute', inset: 0, background: 'rgba(12,10,9,.55)' }} />
+                  <div style={{ position: 'relative', fontSize: 12, color: 'var(--fg-light)', fontWeight: 600 }}>
+                    {stat.stage}
+                  </div>
+                  <div style={{ position: 'relative', fontFamily: 'var(--font-mono)', fontSize: 28, fontWeight: 700, color: 'var(--aqua)' }}>
+                    {stat.count}
+                  </div>
                 </div>
-                <div style={{
-                  position: 'relative',
-                  zIndex: 2,
-                  fontSize: '2rem',
-                  fontWeight: 'bold',
-                  color: '#83a598',
-                  textShadow: '0 2px 4px rgba(0,0,0,0.9)'
-                }}>
-                  {stat.count}
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       )}
 
       {/* Matches */}
-      <div style={{ marginTop: '2rem' }}>
-        <h3 style={{ fontSize: '1.3rem', marginBottom: '1rem', color: '#fbf1c7', fontWeight: 'bold' }}>
-          Matches
-        </h3>
-        <div style={{
-          background: '#3c3836',
-          borderRadius: '12px',
-          border: '1px solid #504945',
-          padding: '0.75rem'
-        }}>
+      <div>
+        <SectionTitle>Matches</SectionTitle>
+        <Card style={{ borderRadius: 14 }} padding={12}>
           {matchesLoading && (
-            <div style={{ fontSize: '0.85rem', color: '#a89984', padding: '0.5rem' }}>Loading matches...</div>
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--gray)', padding: 8 }}>Loading matches...</div>
           )}
           {matchesError && (
-            <div className="error" style={{ fontSize: '0.85rem', padding: '0.5rem' }}>{matchesError}</div>
+            <div className="error" style={{ fontSize: 12, padding: 8 }}>{matchesError}</div>
           )}
           {!matchesLoading && !matchesError && matches.length === 0 && (
-            <div style={{ fontSize: '0.85rem', color: '#a89984', padding: '0.5rem' }}>No matches found for this session.</div>
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--gray)', padding: 8 }}>No matches found for this session.</div>
           )}
           {!matchesLoading && !matchesError && matches.map((match) => {
             const isShayneWin = match.winner === 'Shayne';
+            const winColor = isShayneWin ? 'var(--shayne)' : 'var(--matt)';
             return (
               <div
                 key={match.match_id}
                 style={{
                   display: 'flex',
                   alignItems: 'center',
-                  gap: '0.75rem',
+                  gap: 12,
                   flexWrap: 'wrap',
-                  padding: '0.6rem 0.5rem',
-                  borderBottom: '1px solid #504945',
-                  borderLeft: `3px solid ${isShayneWin ? '#fe8019' : '#b8bb26'}`,
-                  borderRadius: '4px',
-                  marginBottom: '0.25rem',
-                  background: '#32302f'
+                  padding: '10px 8px',
+                  borderBottom: '1px solid var(--line-2)',
                 }}
               >
-                <span style={{ fontSize: '0.75rem', color: '#a89984', fontVariantNumeric: 'tabular-nums', minWidth: '40px' }}>
-                  {formatMatchTime(match.datetime)}
+                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--gray)', minWidth: 40 }}>
+                  {matchTime(match.datetime)}
                 </span>
-                <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.4rem', flex: 1, minWidth: '160px', fontSize: '0.85rem' }}>
-                  <span style={{ color: '#fe8019' }}>
-                    <CharacterDisplay character={match.shayne_character} />
-                  </span>
-                  <span style={{ color: '#a89984', fontSize: '0.75rem' }}>vs</span>
-                  <span style={{ color: '#b8bb26' }}>
-                    <CharacterDisplay character={match.matt_character} />
-                  </span>
+                <span style={{ flex: 1, minWidth: 160, fontSize: 13, display: 'inline-flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+                  <span style={{ color: 'var(--shayne)' }}>{match.shayne_character}</span>
+                  <span style={{ color: 'var(--faint)', fontSize: 11 }}>vs</span>
+                  <span style={{ color: 'var(--matt)' }}>{match.matt_character}</span>
                 </span>
-                <span style={{
-                  fontSize: '0.7rem',
-                  fontWeight: 'bold',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.5px',
-                  color: '#282828',
-                  background: isShayneWin ? '#fe8019' : '#b8bb26',
-                  borderRadius: '4px',
-                  padding: '0.15rem 0.5rem'
-                }}>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 11,
+                    fontWeight: 700,
+                    color: winColor,
+                    background: `color-mix(in srgb, ${winColor} 18%, transparent)`,
+                    borderRadius: 6,
+                    padding: '2px 8px',
+                  }}
+                >
                   {match.winner}
                 </span>
-                <span style={{ fontSize: '0.75rem', color: '#a89984', minWidth: '90px' }}>
+                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--gray)', minWidth: 110 }}>
                   {match.stage || 'No stage'}
                 </span>
-                <span style={{ fontSize: '0.75rem', color: '#a89984', minWidth: '38px', textAlign: 'right' }}>
-                  {formatStocks(match.stocks_remaining)}
+                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--gray)', minWidth: 44, textAlign: 'right' }}>
+                  {stocksLabel(match.stocks_remaining ?? null)}
                 </span>
                 <button
                   type="button"
@@ -568,21 +428,19 @@ function SessionDetail() {
                   style={{
                     background: 'none',
                     border: 'none',
-                    color: '#a89984',
-                    fontSize: '0.9rem',
+                    color: 'var(--gray)',
+                    fontSize: 14,
                     cursor: 'pointer',
-                    padding: '0.2rem',
-                    lineHeight: 1
+                    padding: 2,
+                    lineHeight: 1,
                   }}
-                  onMouseEnter={(e) => { e.currentTarget.style.color = '#fbf1c7'; }}
-                  onMouseLeave={(e) => { e.currentTarget.style.color = '#a89984'; }}
                 >
                   ✎
                 </button>
               </div>
             );
           })}
-        </div>
+        </Card>
       </div>
 
       {editingMatch && (
@@ -592,9 +450,8 @@ function SessionDetail() {
           onSaved={handleMatchSaved}
         />
       )}
-    </div>
+    </PageColumn>
   );
 }
 
 export default SessionDetail;
-

--- a/frontend/src/SessionHistory.tsx
+++ b/frontend/src/SessionHistory.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { BarChart, Bar, XAxis, YAxis, Legend, Tooltip } from './components/dither';
+import { LoadingState, ErrorState } from './components/Feedback';
+import { PageColumn, PageHeader, SectionTitle, Card, StatTile } from './components/ui';
+import { SplitBar } from './session/components/bars';
+import { formatDuration, sessionDisplayName } from './session/format';
 
 interface Session {
   session_id: string;
@@ -46,14 +50,14 @@ function SessionHistory() {
     try {
       const res = await fetch('/api/sessions');
       const data = await res.json();
-      
+
       if (!data.success) {
         throw new Error(data.message || 'Failed to load sessions');
       }
-      
+
       setSessions(data.sessions);
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load sessions');
     } finally {
       setLoading(false);
     }
@@ -63,7 +67,7 @@ function SessionHistory() {
     try {
       const res = await fetch('/api/sessions/timeline');
       const data = await res.json();
-      
+
       if (data.success && data.data) {
         setTimelineData(data.data);
       }
@@ -74,38 +78,30 @@ function SessionHistory() {
 
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);
-    return date.toLocaleDateString('en-US', { 
-      month: 'short', 
-      day: 'numeric', 
-      year: 'numeric' 
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
     });
   };
 
   const formatTime = (dateStr: string) => {
     const date = new Date(dateStr);
-    return date.toLocaleTimeString('en-US', { 
-      hour: 'numeric', 
-      minute: '2-digit' 
+    return date.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
     });
   };
 
-  const formatDuration = (minutes: number) => {
-    if (minutes < 60) {
-      return `${minutes}m`;
-    }
-    const hours = Math.floor(minutes / 60);
-    const mins = minutes % 60;
-    return `${hours}h ${mins}m`;
-  };
-
-  const filteredSessions = sessions.filter(s => s.total_games >= filterMinGames);
+  const filteredSessions = sessions.filter((s) => s.total_games >= filterMinGames);
 
   // Calculate statistics
   const totalGames = sessions.reduce((sum, s) => sum + s.total_games, 0);
   const avgGamesPerSession = sessions.length > 0 ? (totalGames / sessions.length).toFixed(1) : 0;
-  const avgDuration = sessions.length > 0 
-    ? Math.round(sessions.reduce((sum, s) => sum + s.duration_minutes, 0) / sessions.length)
-    : 0;
+  const avgDuration =
+    sessions.length > 0
+      ? Math.round(sessions.reduce((sum, s) => sum + s.duration_minutes, 0) / sessions.length)
+      : 0;
 
   // Timeline chart rows: one bar pair per session, stacked so total height = games played
   const activityChartData: ActivityChartRow[] = timelineData.map((d) => ({
@@ -114,173 +110,47 @@ function SessionHistory() {
     matt_wins: d.matt_wins,
   }));
 
-  if (loading) {
-    return (
-      <div style={{ 
-        padding: '2rem', 
-        textAlign: 'center',
-        color: '#a89984' 
-      }}>
-        Loading sessions...
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div style={{ 
-        padding: '2rem', 
-        textAlign: 'center',
-        color: '#fb4934' 
-      }}>
-        Error: {error}
-      </div>
-    );
-  }
+  if (loading) return <LoadingState label="Loading sessions…" />;
+  if (error) return <ErrorState message={error} onRetry={fetchSessions} />;
 
   return (
-    <div style={{ 
-      padding: '2rem',
-      maxWidth: '1400px',
-      margin: '0 auto'
-    }}>
-      {/* Header */}
-      <div style={{ 
-        display: 'flex', 
-        justifyContent: 'space-between', 
-        alignItems: 'flex-start',
-        marginBottom: '1.5rem' 
-      }}>
-        <div>
-          <h1 style={{ 
-            fontSize: '1.5rem', 
-            fontWeight: 'bold',
-            color: '#fbf1c7',
-            marginBottom: '0.25rem'
-          }}>
-            📊 Session History
-          </h1>
-          <p style={{ color: '#a89984', fontSize: '0.8rem' }}>
-            View and analyze all your gaming sessions
-          </p>
-        </div>
-        <Link
-          to="/sessions/compare"
-          style={{
-            padding: '0.5rem 1rem',
-            background: '#83a598',
-            color: '#282828',
-            border: 'none',
-            borderRadius: '6px',
-            fontSize: '0.8rem',
-            fontWeight: 'bold',
-            textDecoration: 'none',
-            display: 'inline-block',
-            transition: 'all 0.2s'
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.background = '#a3c0b8';
-            e.currentTarget.style.transform = 'translateY(-1px)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.background = '#83a598';
-            e.currentTarget.style.transform = 'none';
-          }}
-        >
-          🔄 Compare Sessions
-        </Link>
+    <PageColumn>
+      <PageHeader
+        title="Session History"
+        subtitle="View and analyze all your gaming sessions"
+        action={
+          <Link
+            to="/sessions/compare"
+            style={{
+              background: 'var(--blue)',
+              color: '#1b1817',
+              borderRadius: 12,
+              padding: '11px 18px',
+              fontWeight: 700,
+              fontSize: 13,
+              fontFamily: 'var(--font-display)',
+              textDecoration: 'none',
+              display: 'inline-block',
+            }}
+          >
+            ⇄ Compare sessions
+          </Link>
+        }
+      />
+
+      {/* summary tiles */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(150px,1fr))', gap: 14 }}>
+        <StatTile caps value={sessions.length} label="Total sessions" color="var(--blue)" />
+        <StatTile caps value={totalGames} label="Total games" color="var(--yellow)" />
+        <StatTile caps value={avgGamesPerSession} label="Avg games/session" color="var(--aqua)" />
+        <StatTile caps value={formatDuration(avgDuration)} label="Avg duration" color="var(--purple)" />
       </div>
 
-      {/* Summary Stats */}
-      <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
-        gap: '0.75rem',
-        marginBottom: '1.5rem'
-      }}>
-        <div style={{
-          background: '#3c3836',
-          borderRadius: '8px',
-          padding: '0.875rem',
-          border: '1px solid #504945'
-        }}>
-          <div style={{ fontSize: '0.625rem', color: '#a89984', marginBottom: '0.375rem', textTransform: 'uppercase' }}>
-            Total Sessions
-          </div>
-          <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#83a598' }}>
-            {sessions.length}
-          </div>
-        </div>
-
-        <div style={{
-          background: '#3c3836',
-          borderRadius: '8px',
-          padding: '0.875rem',
-          border: '1px solid #504945'
-        }}>
-          <div style={{ fontSize: '0.625rem', color: '#a89984', marginBottom: '0.375rem', textTransform: 'uppercase' }}>
-            Total Games
-          </div>
-          <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#b8bb26' }}>
-            {totalGames}
-          </div>
-        </div>
-
-        <div style={{
-          background: '#3c3836',
-          borderRadius: '8px',
-          padding: '0.875rem',
-          border: '1px solid #504945'
-        }}>
-          <div style={{ fontSize: '0.625rem', color: '#a89984', marginBottom: '0.375rem', textTransform: 'uppercase' }}>
-            Avg Games/Session
-          </div>
-          <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#fabd2f' }}>
-            {avgGamesPerSession}
-          </div>
-        </div>
-
-        <div style={{
-          background: '#3c3836',
-          borderRadius: '8px',
-          padding: '0.875rem',
-          border: '1px solid #504945'
-        }}>
-          <div style={{ fontSize: '0.625rem', color: '#a89984', marginBottom: '0.375rem', textTransform: 'uppercase' }}>
-            Avg Duration
-          </div>
-          <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#fe8019' }}>
-            {formatDuration(avgDuration)}
-          </div>
-        </div>
-      </div>
-
-      {/* Timeline Chart */}
+      {/* activity over time */}
       {timelineData.length > 0 && (
-        <div style={{
-          background: '#3c3836',
-          borderRadius: '12px',
-          padding: '1.5rem',
-          marginBottom: '1.5rem',
-          border: '1px solid #504945',
-          boxShadow: '0 2px 8px rgba(0,0,0,0.2)'
-        }}>
-          <h2 style={{ 
-            fontSize: '1.2rem', 
-            marginBottom: '1rem', 
-            color: '#fbf1c7',
-            fontWeight: 'bold'
-          }}>
-            📊 Session Activity Over Time
-          </h2>
-          <div style={{ 
-            fontSize: '0.85rem', 
-            color: '#a89984', 
-            marginBottom: '1rem' 
-          }}>
-            Games played across {timelineData.length} session{timelineData.length !== 1 ? 's' : ''}
-          </div>
-          <div style={{ height: '300px', width: '100%' }}>
+        <Card>
+          <SectionTitle hint="Shayne / Matt">Session activity over time</SectionTitle>
+          <div style={{ height: 260, width: '100%' }}>
             <BarChart
               data={activityChartData}
               config={{
@@ -297,192 +167,149 @@ function SessionHistory() {
               <Bar dataKey="matt_wins" variant="gradient" />
             </BarChart>
           </div>
-        </div>
+        </Card>
       )}
 
-      {/* Filter */}
-      <div style={{
-        background: '#3c3836',
-        borderRadius: '8px',
-        padding: '0.75rem',
-        marginBottom: '1.25rem',
-        border: '1px solid #504945',
-        display: 'flex',
-        alignItems: 'center',
-        gap: '0.75rem'
-      }}>
-        <label style={{ color: '#ebdbb2', fontSize: '0.75rem' }}>
-          Minimum Games:
-        </label>
+      {/* filter bar */}
+      <div
+        style={{
+          background: 'var(--panel)',
+          border: '1px solid var(--line-2)',
+          borderRadius: 12,
+          padding: '12px 16px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 14,
+          flexWrap: 'wrap',
+        }}
+      >
+        <label style={{ fontSize: 13, color: 'var(--fg)' }}>Minimum games</label>
         <input
           type="number"
           min="0"
           value={filterMinGames}
           onChange={(e) => setFilterMinGames(parseInt(e.target.value) || 0)}
           style={{
-            background: '#282828',
-            border: '1px solid #504945',
-            borderRadius: '4px',
-            padding: '0.375rem',
-            color: '#ebdbb2',
-            width: '60px',
-            fontSize: '0.75rem'
+            background: 'var(--deep1)',
+            border: '1px solid var(--border-light)',
+            borderRadius: 8,
+            padding: '6px 10px',
+            color: 'var(--fg)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 13,
+            width: 64,
           }}
         />
-        <span style={{ color: '#a89984', fontSize: '0.7rem' }}>
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--faint)' }}>
           Showing {filteredSessions.length} of {sessions.length} sessions
         </span>
       </div>
 
-      {/* Sessions List */}
-      <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
-        gap: '1rem'
-      }}>
+      {/* session card grid */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(280px,1fr))', gap: 16 }}>
         {filteredSessions.map((session) => {
-          const shayneWinRate = session.total_games > 0 
-            ? (session.shayne_wins / session.total_games * 100).toFixed(1)
-            : 0;
-          const winner = session.shayne_wins > session.matt_wins ? 'Shayne' : 
-                        session.matt_wins > session.shayne_wins ? 'Matt' : 'Tie';
-          
+          const winner =
+            session.shayne_wins > session.matt_wins
+              ? 'Shayne'
+              : session.matt_wins > session.shayne_wins
+              ? 'Matt'
+              : 'Even';
+          const badge =
+            winner === 'Shayne'
+              ? { color: 'var(--shayne)', bg: 'rgba(254,128,25,0.15)' }
+              : winner === 'Matt'
+              ? { color: 'var(--matt)', bg: 'rgba(184,187,38,0.15)' }
+              : { color: 'var(--gray)', bg: 'rgba(168,153,132,0.15)' };
+
           return (
             <Link
               key={session.session_id}
-              to={`/sessions/${session.session_id}`}
-              style={{ textDecoration: 'none' }}
+              to={`/sessions/${encodeURIComponent(session.session_id)}`}
+              style={{
+                background: 'var(--panel)',
+                border: '1px solid var(--line-2)',
+                borderRadius: 16,
+                padding: 18,
+                cursor: 'pointer',
+                textDecoration: 'none',
+                color: 'inherit',
+                display: 'block',
+              }}
             >
-              <div style={{
-                background: '#3c3836',
-                borderRadius: '8px',
-                padding: '0.875rem',
-                border: '1px solid #504945',
-                transition: 'all 0.2s',
-                cursor: 'pointer'
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.background = '#504945';
-                e.currentTarget.style.transform = 'translateY(-2px)';
-                e.currentTarget.style.boxShadow = '0 4px 12px rgba(0,0,0,0.3)';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.background = '#3c3836';
-                e.currentTarget.style.transform = 'none';
-                e.currentTarget.style.boxShadow = 'none';
-              }}>
-                {/* Date Header */}
-                <div style={{ 
-                  marginBottom: '0.625rem',
-                  paddingBottom: '0.5rem',
-                  borderBottom: '1px solid #504945'
-                }}>
-                  <div style={{ 
-                    fontSize: '0.85rem', 
-                    fontWeight: 'bold',
-                    color: '#fbf1c7',
-                    marginBottom: '0.125rem'
-                  }}>
-                    📅 {formatDate(session.start_time)}
-                  </div>
-                  <div style={{ 
-                    fontSize: '0.7rem',
-                    color: '#a89984'
-                  }}>
-                    {formatTime(session.start_time)} → {formatTime(session.end_time)}
-                  </div>
+              {/* header */}
+              <div style={{ paddingBottom: 12, marginBottom: 12, borderBottom: '1px solid var(--line-2)' }}>
+                <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--fg-light)' }}>
+                  {sessionDisplayName(session.start_time)}
                 </div>
-
-                {/* Game Count and Duration */}
-                <div style={{
-                  display: 'flex',
-                  gap: '1rem',
-                  marginBottom: '0.625rem'
-                }}>
-                  <div>
-                    <div style={{ fontSize: '0.625rem', color: '#a89984', marginBottom: '0.125rem' }}>
-                      Games
-                    </div>
-                    <div style={{ fontSize: '1.125rem', fontWeight: 'bold', color: '#83a598' }}>
-                      {session.total_games}
-                    </div>
-                  </div>
-                  <div>
-                    <div style={{ fontSize: '0.625rem', color: '#a89984', marginBottom: '0.125rem' }}>
-                      Duration
-                    </div>
-                    <div style={{ fontSize: '1.125rem', fontWeight: 'bold', color: '#fabd2f' }}>
-                      {formatDuration(session.duration_minutes)}
-                    </div>
-                  </div>
+                <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--gray)', marginTop: 3 }}>
+                  {formatDate(session.start_time)}
                 </div>
-
-                {/* Score */}
-                <div style={{ marginBottom: '0.5rem' }}>
-                  <div style={{ 
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                    marginBottom: '0.375rem'
-                  }}>
-                    <span style={{ fontSize: '0.95rem', fontWeight: 'bold', color: '#fe8019' }}>
-                      Shayne {session.shayne_wins}
-                    </span>
-                    <span style={{ fontSize: '0.75rem', color: '#a89984' }}>-</span>
-                    <span style={{ fontSize: '0.95rem', fontWeight: 'bold', color: '#b8bb26' }}>
-                      {session.matt_wins} Matt
-                    </span>
-                  </div>
-                  
-                  {/* Win Rate Bar */}
-                  <div style={{
-                    height: '4px',
-                    background: '#282828',
-                    borderRadius: '2px',
-                    overflow: 'hidden',
-                    display: 'flex'
-                  }}>
-                    <div style={{
-                      width: `${shayneWinRate}%`,
-                      background: '#fe8019'
-                    }} />
-                    <div style={{
-                      width: `${100 - parseFloat(shayneWinRate as string)}%`,
-                      background: '#b8bb26'
-                    }} />
-                  </div>
-                </div>
-
-                {/* Winner Badge */}
-                <div style={{
-                  display: 'inline-block',
-                  padding: '0.25rem 0.5rem',
-                  borderRadius: '12px',
-                  fontSize: '0.65rem',
-                  fontWeight: 'bold',
-                  background: winner === 'Tie' ? '#83a598' : winner === 'Shayne' ? '#fe8019' : '#b8bb26',
-                  color: '#282828'
-                }}>
-                  {winner === 'Tie' ? '🤝 Tied' : `🏆 ${winner} Won`}
+                <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--faint)', marginTop: 2 }}>
+                  {formatTime(session.start_time)} → {formatTime(session.end_time)}
                 </div>
               </div>
+
+              {/* games + duration */}
+              <div style={{ display: 'flex', gap: 24, marginBottom: 14 }}>
+                <div>
+                  <div style={{ fontSize: 10, color: 'var(--gray)', fontFamily: 'var(--font-mono)', textTransform: 'uppercase', marginBottom: 2 }}>
+                    Games
+                  </div>
+                  <div style={{ fontFamily: 'var(--font-mono)', fontSize: 18, fontWeight: 700, color: 'var(--aqua)' }}>
+                    {session.total_games}
+                  </div>
+                </div>
+                <div>
+                  <div style={{ fontSize: 10, color: 'var(--gray)', fontFamily: 'var(--font-mono)', textTransform: 'uppercase', marginBottom: 2 }}>
+                    Duration
+                  </div>
+                  <div style={{ fontFamily: 'var(--font-mono)', fontSize: 18, fontWeight: 700, color: 'var(--yellow)' }}>
+                    {formatDuration(session.duration_minutes)}
+                  </div>
+                </div>
+              </div>
+
+              {/* score */}
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+                <span style={{ fontSize: 14, fontWeight: 700, color: 'var(--shayne)' }}>
+                  Shayne {session.shayne_wins}
+                </span>
+                <span style={{ fontSize: 14, fontWeight: 700, color: 'var(--matt)' }}>
+                  {session.matt_wins} Matt
+                </span>
+              </div>
+
+              <div style={{ marginBottom: 14 }}>
+                <SplitBar shayne={session.shayne_wins} matt={session.matt_wins} height={6} radius={3} />
+              </div>
+
+              {/* winner badge */}
+              <span
+                style={{
+                  display: 'inline-block',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 10,
+                  fontWeight: 700,
+                  padding: '3px 9px',
+                  borderRadius: 6,
+                  color: badge.color,
+                  background: badge.bg,
+                }}
+              >
+                {winner}
+              </span>
             </Link>
           );
         })}
       </div>
 
       {filteredSessions.length === 0 && (
-        <div style={{
-          textAlign: 'center',
-          padding: '3rem',
-          color: '#a89984'
-        }}>
-          No sessions found matching your criteria
+        <div style={{ textAlign: 'center', padding: '3rem', color: 'var(--faint)' }}>
+          No sessions match your filter
         </div>
       )}
-    </div>
+    </PageColumn>
   );
 }
 
 export default SessionHistory;
-

--- a/frontend/src/SessionTearsheet.tsx
+++ b/frontend/src/SessionTearsheet.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import html2canvas from 'html2canvas';
 import CharacterDisplay from './components/CharacterDisplay';
+import CharToken from './session/components/CharToken';
 import { LoadingState, ErrorState } from './components/Feedback';
 import { stageImages } from './lib/stages';
 
@@ -69,10 +70,43 @@ interface Game {
   stocks_remaining: number;
 }
 
+// The tearsheet card uses LITERAL hex (not CSS vars): it's a fixed shareable PNG
+// artifact captured by html2canvas, and must render identically regardless of
+// theme or var-resolution quirks in the capture engine.
+const HEX = {
+  card: '#161312',
+  panel: '#1b1817',
+  sub: '#221f1e',
+  line: '#2a2624',
+  line2: '#3c3836',
+  fg: '#ebdbb2',
+  fgLight: '#fbf1c7',
+  dim: '#a89984',
+  faint: '#665c54',
+  bl: '#504945',
+  shayne: '#fe8019',
+  matt: '#b8bb26',
+  blue: '#83a598',
+  aqua: '#8ec07c',
+  yellow: '#d79921',
+};
+
+function topCharacter(usage: CharacterUsage): string {
+  let best = '';
+  let bestN = -1;
+  for (const [c, n] of Object.entries(usage)) {
+    if (n > bestN) {
+      bestN = n;
+      best = c;
+    }
+  }
+  return best;
+}
+
 function SessionTearsheet() {
   const [searchParams] = useSearchParams();
   const sessionId = searchParams.get('session_id');
-  
+
   const [stats, setStats] = useState<SessionStatsData | null>(null);
   const [lifetimeStats, setLifetimeStats] = useState<LifetimeStats | null>(null);
   const [headToHead, setHeadToHead] = useState<HeadToHeadStats | null>(null);
@@ -87,11 +121,10 @@ function SessionTearsheet() {
     setLoading(true);
     setError(null);
     try {
-      // Build session stats URL with optional session_id parameter
-      const sessionStatsUrl = sessionId 
+      const sessionStatsUrl = sessionId
         ? `/api/session_stats?session_id=${sessionId}`
         : '/api/session_stats';
-      
+
       const [sessionRes, lifetimeRes, h2hRes, advRes, gamesRes] = await Promise.all([
         fetch(sessionStatsUrl),
         fetch('/api/stats'),
@@ -99,26 +132,26 @@ function SessionTearsheet() {
         fetch('/api/advanced_metrics'),
         fetch('/api/recent_games'),
       ]);
-      
+
       const sessionData = await sessionRes.json();
       const lifetimeData = await lifetimeRes.json();
       const h2hData = await h2hRes.json();
       const advData = await advRes.json();
       const gamesData = await gamesRes.json();
-      
+
       if (!sessionData.success) throw new Error(sessionData.message || 'Failed to load session stats');
       if (!lifetimeData.success) throw new Error(lifetimeData.message || 'Failed to load lifetime stats');
       if (!h2hData.success) throw new Error(h2hData.message || 'Failed to load head-to-head stats');
       if (!advData.success) throw new Error(advData.message || 'Failed to load advanced metrics');
       if (!gamesData.success) throw new Error(gamesData.message || 'Failed to load recent games');
-      
+
       setStats(sessionData);
       setLifetimeStats(lifetimeData.stats);
       setHeadToHead(h2hData);
       setAdvancedMetrics(advData);
       setRecentGames(gamesData.games);
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load session stats');
     } finally {
       setLoading(false);
     }
@@ -130,17 +163,14 @@ function SessionTearsheet() {
 
   const generatePNG = async () => {
     if (!tearsheetRef.current) return;
-    
     setGenerating(true);
     try {
       const canvas = await html2canvas(tearsheetRef.current, {
-        backgroundColor: '#282828',
+        backgroundColor: HEX.card,
         scale: 2,
         logging: false,
         useCORS: true,
       });
-      
-      // Convert to blob and download
       canvas.toBlob((blob) => {
         if (blob) {
           const url = URL.createObjectURL(blob);
@@ -162,22 +192,18 @@ function SessionTearsheet() {
 
   const copyToClipboard = async () => {
     if (!tearsheetRef.current) return;
-    
     setGenerating(true);
     try {
       const canvas = await html2canvas(tearsheetRef.current, {
-        backgroundColor: '#282828',
+        backgroundColor: HEX.card,
         scale: 2,
         logging: false,
         useCORS: true,
       });
-      
       canvas.toBlob(async (blob) => {
         if (blob) {
           try {
-            await navigator.clipboard.write([
-              new ClipboardItem({ 'image/png': blob })
-            ]);
+            await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
             alert('Session stats copied to clipboard!');
           } catch (err) {
             console.error('Failed to copy to clipboard:', err);
@@ -200,844 +226,256 @@ function SessionTearsheet() {
 
   if (loading) {
     return (
-      <div style={{ 
-        minHeight: '100vh', 
-        background: '#282828', 
-        color: '#ebdbb2',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: '2rem'
-      }}>
-        <LoadingState label="Loading session stats..." />
+      <div style={{ minHeight: '100vh', background: 'var(--deep0)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '2rem' }}>
+        <LoadingState label="Loading session stats…" />
       </div>
     );
   }
 
   if (error || !stats || !lifetimeStats || !headToHead || !advancedMetrics) {
     return (
-      <div style={{ 
-        minHeight: '100vh', 
-        background: '#282828', 
-        color: '#ebdbb2',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: '2rem'
-      }}>
+      <div style={{ minHeight: '100vh', background: 'var(--deep0)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '2rem' }}>
         <ErrorState message={error || 'Failed to load session stats'} onRetry={fetchData} />
       </div>
     );
   }
 
-  // Format date based on whether we have session data with start/end times
   const getSessionDateDisplay = () => {
     if (stats && 'start_time' in stats && 'end_time' in stats) {
-      const start = new Date((stats as any).start_time);
-      const end = new Date((stats as any).end_time);
-      
-      // Check if session spans multiple days
+      const start = new Date((stats as unknown as { start_time: string }).start_time);
+      const end = new Date((stats as unknown as { end_time: string }).end_time);
       const sameDay = start.toDateString() === end.toDateString();
-      
       if (sameDay) {
-        return start.toLocaleDateString('en-US', { 
-          weekday: 'long', 
-          year: 'numeric', 
-          month: 'long', 
-          day: 'numeric' 
-        });
-      } else {
-        const startStr = start.toLocaleDateString('en-US', { 
-          month: 'short', 
-          day: 'numeric',
-          hour: 'numeric',
-          minute: '2-digit'
-        });
-        const endStr = end.toLocaleDateString('en-US', { 
-          month: 'short', 
-          day: 'numeric',
-          year: 'numeric',
-          hour: 'numeric',
-          minute: '2-digit'
-        });
-        return `${startStr} → ${endStr}`;
+        return start.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
       }
+      const startStr = start.toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+      const endStr = end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' });
+      return `${startStr} → ${endStr}`;
     }
-    
-    // Fallback to today's date
-    return new Date().toLocaleDateString('en-US', { 
-      weekday: 'long', 
-      year: 'numeric', 
-      month: 'long', 
-      day: 'numeric' 
-    });
+    return new Date().toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
   };
-  
+
   const sessionDateDisplay = getSessionDateDisplay();
+  const streak = headToHead.streaks.current_streak;
+  const last10 = headToHead.recent_form.last_10;
+  const last10Total = last10.total_games || 1;
+  const topShayne = topCharacter(stats.shayne_characters);
+  const topMatt = topCharacter(stats.matt_characters);
+
+  const mono = "'IBM Plex Mono', monospace";
+  const display = "'Space Grotesk', sans-serif";
+  const toolBtn = (bg: string, color: string): React.CSSProperties => ({
+    display: 'flex', alignItems: 'center', gap: 8, background: bg, border: 'none', borderRadius: 11,
+    padding: '11px 18px', color, fontFamily: display, fontSize: 13, fontWeight: 700,
+    cursor: generating ? 'not-allowed' : 'pointer', opacity: generating ? 0.6 : 1,
+  });
 
   return (
-    <div style={{ 
-      minHeight: '100vh', 
-      background: '#1d2021', 
-      color: '#ebdbb2',
-      padding: '2rem',
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      gap: '2rem'
-    }}>
-      {/* Action Buttons */}
-      <div style={{ 
-        display: 'flex', 
-        gap: '1rem',
-        position: 'sticky',
-        top: '1rem',
-        zIndex: 100,
-        background: '#282828',
-        padding: '1rem',
-        borderRadius: '12px',
-        border: '1px solid #504945',
-        boxShadow: '0 4px 12px rgba(0,0,0,0.3)'
-      }}>
-        <button
-          onClick={copyToClipboard}
-          disabled={generating}
-          style={{
-            padding: '0.75rem 1.5rem',
-            background: '#83a598',
-            color: '#282828',
-            border: 'none',
-            borderRadius: '8px',
-            fontSize: '1rem',
-            fontWeight: 'bold',
-            cursor: generating ? 'not-allowed' : 'pointer',
-            opacity: generating ? 0.6 : 1,
-            transition: 'all 0.2s'
-          }}
-          onMouseEnter={(e) => !generating && (e.currentTarget.style.background = '#a3c0b8')}
-          onMouseLeave={(e) => (e.currentTarget.style.background = '#83a598')}
-        >
-          {generating ? 'Generating...' : '📋 Copy to Clipboard'}
+    <div style={{ minHeight: '100vh', background: 'var(--deep0)', color: HEX.fg, padding: '32px 20px', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 18 }}>
+      {/* export toolbar (excluded from capture) */}
+      <div style={{ width: 800, maxWidth: '100%', display: 'flex', gap: 10 }}>
+        <button onClick={copyToClipboard} disabled={generating} style={toolBtn(HEX.blue, '#1b1817')}>
+          <span style={{ fontSize: 14 }}>⎘</span>{generating ? 'Generating…' : 'Copy to clipboard'}
         </button>
-        <button
-          onClick={generatePNG}
-          disabled={generating}
-          style={{
-            padding: '0.75rem 1.5rem',
-            background: '#b8bb26',
-            color: '#282828',
-            border: 'none',
-            borderRadius: '8px',
-            fontSize: '1rem',
-            fontWeight: 'bold',
-            cursor: generating ? 'not-allowed' : 'pointer',
-            opacity: generating ? 0.6 : 1,
-            transition: 'all 0.2s'
-          }}
-          onMouseEnter={(e) => !generating && (e.currentTarget.style.background = '#d8db46')}
-          onMouseLeave={(e) => (e.currentTarget.style.background = '#b8bb26')}
-        >
-          {generating ? 'Generating...' : '💾 Download PNG'}
+        <button onClick={generatePNG} disabled={generating} style={toolBtn(HEX.shayne, '#1b1817')}>
+          <span style={{ fontSize: 14 }}>↓</span>{generating ? 'Generating…' : 'Download PNG'}
         </button>
-        <button
-          onClick={() => window.close()}
-          style={{
-            padding: '0.75rem 1.5rem',
-            background: '#504945',
-            color: '#ebdbb2',
-            border: 'none',
-            borderRadius: '8px',
-            fontSize: '1rem',
-            fontWeight: 'bold',
-            cursor: 'pointer',
-            transition: 'all 0.2s'
-          }}
-          onMouseEnter={(e) => (e.currentTarget.style.background = '#665c54')}
-          onMouseLeave={(e) => (e.currentTarget.style.background = '#504945')}
-        >
-          ✕ Close
+        <div style={{ flex: 1 }} />
+        <button onClick={() => window.close()} style={{ background: HEX.sub, border: `1px solid ${HEX.bl}`, borderRadius: 11, padding: '11px 16px', color: HEX.dim, fontFamily: display, fontSize: 13, fontWeight: 600, cursor: 'pointer' }}>
+          Close
         </button>
       </div>
 
-      {/* Tearsheet */}
-      <div 
-        ref={tearsheetRef}
-        style={{
-          width: '800px',
-          background: '#282828',
-          borderRadius: '16px',
-          padding: '2.5rem',
-          boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
-          border: '2px solid #504945'
-        }}
-      >
-        {/* Header */}
-        <div style={{ 
-          textAlign: 'center', 
-          marginBottom: '2rem',
-          borderBottom: '2px solid #504945',
-          paddingBottom: '1.5rem'
-        }}>
-          <h1 style={{ 
-            fontSize: '2.5rem', 
-            fontWeight: 'bold', 
-            margin: 0,
-            marginBottom: '0.5rem',
-            color: '#fbf1c7',
-            textShadow: '2px 2px 4px rgba(0,0,0,0.3)'
-          }}>
-            🎮 Smash Session Stats
-          </h1>
-          <div style={{ fontSize: '1rem', color: '#a89984', fontWeight: '500' }}>
-            {sessionDateDisplay}
-          </div>
+      {/* the tearsheet card (800px export frame) */}
+      <div ref={tearsheetRef} style={{ width: 800, maxWidth: '100%', position: 'relative', overflow: 'hidden', background: HEX.card, border: `1px solid ${HEX.line2}`, borderRadius: 22, boxShadow: '0 30px 70px -25px rgba(0,0,0,0.7)' }}>
+        <div style={{ height: 5, display: 'flex' }}>
+          <div style={{ flex: 1, background: HEX.shayne }} />
+          <div style={{ flex: 1, background: HEX.matt }} />
         </div>
-
-        {/* ========== LIFETIME STATS SECTION ========== */}
-        <div style={{
-          background: '#1d2021',
-          borderRadius: '16px',
-          padding: '1.5rem',
-          marginBottom: '2.5rem',
-          border: '2px solid #3c3836',
-          boxShadow: 'inset 0 2px 8px rgba(0,0,0,0.3)'
-        }}>
-          {/* Section Title */}
-          <div style={{
-            textAlign: 'center',
-            marginBottom: '1.25rem',
-            paddingBottom: '0.75rem',
-            borderBottom: '2px solid #3c3836'
-          }}>
-            <div style={{
-              fontSize: '1rem',
-              fontWeight: 'bold',
-              color: '#d79921',
-              textTransform: 'uppercase',
-              letterSpacing: '2px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: '0.5rem'
-            }}>
-              <span>📊</span>
-              <span>Lifetime Statistics</span>
-              <span>📊</span>
+        <div style={{ padding: '38px 40px' }}>
+          {/* header lockup */}
+          <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 20, paddingBottom: 24, borderBottom: `1px solid ${HEX.line}` }}>
+            <div>
+              <div style={{ fontFamily: mono, fontSize: 11, letterSpacing: 3, color: HEX.shayne, textTransform: 'uppercase' }}>Session Tearsheet</div>
+              <div style={{ fontSize: 30, fontWeight: 700, color: HEX.fgLight, letterSpacing: '-0.5px', marginTop: 8, fontFamily: display }}>Session Recap</div>
+              <div style={{ fontFamily: mono, fontSize: 12, color: HEX.dim, marginTop: 4 }}>{sessionDateDisplay} · {stats.total_games} games</div>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <CharToken character={topShayne} player="Shayne" size={44} radius={12} />
+              <span style={{ fontFamily: mono, fontSize: 13, color: HEX.faint }}>vs</span>
+              <CharToken character={topMatt} player="Matt" size={44} radius={12} />
             </div>
           </div>
 
-          {/* Lifetime Stats Content */}
-          <div style={{ 
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            gap: '2rem',
-            marginBottom: '1.5rem'
-          }}>
-            <div style={{ flex: 1, textAlign: 'center' }}>
-              <div style={{ fontSize: '0.75rem', color: '#a89984', marginBottom: '0.5rem', textTransform: 'uppercase', letterSpacing: '1px' }}>
-                All-Time Record
-              </div>
-              <div style={{ fontSize: '1.8rem', fontWeight: 'bold' }}>
-                <span style={{ color: '#fe8019' }}>{lifetimeStats.shayne_wins}</span>
-                <span style={{ color: '#504945', margin: '0 0.5rem' }}>-</span>
-                <span style={{ color: '#b8bb26' }}>{lifetimeStats.matt_wins}</span>
-              </div>
-              <div style={{ fontSize: '0.75rem', color: '#a89984', marginTop: '0.3rem' }}>
-                {lifetimeStats.total_games} total games
-              </div>
-            </div>
-            <div style={{ width: '2px', height: '60px', background: '#3c3836' }} />
-            <div style={{ flex: 1, textAlign: 'center' }}>
-              <div style={{ fontSize: '0.75rem', color: '#a89984', marginBottom: '0.5rem', textTransform: 'uppercase', letterSpacing: '1px' }}>
-                Win Rates
-              </div>
-              <div style={{ display: 'flex', gap: '1.5rem', justifyContent: 'center', alignItems: 'center' }}>
-                <div>
-                  <div style={{ fontSize: '1.4rem', fontWeight: 'bold', color: '#fe8019' }}>
-                    {lifetimeStats.shayne_win_rate.toFixed(1)}%
-                  </div>
-                  <div style={{ fontSize: '0.7rem', color: '#a89984' }}>Shayne</div>
+          {/* lifetime strip */}
+          <div style={{ marginTop: 24, background: HEX.panel, border: `1px solid ${HEX.line}`, borderRadius: 16, padding: '18px 20px' }}>
+            <div style={{ fontFamily: mono, fontSize: 10, letterSpacing: 2, color: HEX.yellow, textTransform: 'uppercase', textAlign: 'center', marginBottom: 16 }}>Lifetime statistics</div>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1px 1fr 1px 1fr', gap: 20, alignItems: 'center' }}>
+              <div style={{ textAlign: 'center' }}>
+                <div style={{ fontSize: 10, color: HEX.dim, fontFamily: mono, textTransform: 'uppercase', letterSpacing: 1, marginBottom: 6 }}>All-time record</div>
+                <div style={{ fontFamily: mono, fontSize: 24, fontWeight: 700 }}>
+                  <span style={{ color: HEX.shayne }}>{lifetimeStats.shayne_wins}</span><span style={{ color: HEX.bl }}>–</span><span style={{ color: HEX.matt }}>{lifetimeStats.matt_wins}</span>
                 </div>
-                <div>
-                  <div style={{ fontSize: '1.4rem', fontWeight: 'bold', color: '#b8bb26' }}>
-                    {lifetimeStats.matt_win_rate.toFixed(1)}%
-                  </div>
-                  <div style={{ fontSize: '0.7rem', color: '#a89984' }}>Matt</div>
+                <div style={{ fontSize: 10, color: HEX.faint, fontFamily: mono, marginTop: 3 }}>{lifetimeStats.total_games.toLocaleString()} games</div>
+              </div>
+              <div style={{ width: 1, height: 44, background: HEX.line }} />
+              <div style={{ textAlign: 'center' }}>
+                <div style={{ fontSize: 10, color: HEX.dim, fontFamily: mono, textTransform: 'uppercase', letterSpacing: 1, marginBottom: 6 }}>Win rates</div>
+                <div style={{ display: 'flex', gap: 18, justifyContent: 'center' }}>
+                  <div><div style={{ fontFamily: mono, fontSize: 18, fontWeight: 700, color: HEX.shayne }}>{lifetimeStats.shayne_win_rate.toFixed(1)}%</div><div style={{ fontSize: 10, color: HEX.dim }}>Shayne</div></div>
+                  <div><div style={{ fontFamily: mono, fontSize: 18, fontWeight: 700, color: HEX.matt }}>{lifetimeStats.matt_win_rate.toFixed(1)}%</div><div style={{ fontSize: 10, color: HEX.dim }}>Matt</div></div>
+                </div>
+              </div>
+              <div style={{ width: 1, height: 44, background: HEX.line }} />
+              <div style={{ textAlign: 'center' }}>
+                <div style={{ fontSize: 10, color: HEX.dim, fontFamily: mono, textTransform: 'uppercase', letterSpacing: 1, marginBottom: 6 }}>Dominance wins</div>
+                <div style={{ display: 'flex', gap: 18, justifyContent: 'center' }}>
+                  <div><div style={{ fontFamily: mono, fontSize: 18, fontWeight: 700, color: HEX.fgLight }}>{advancedMetrics.dominance_factor.shayne.three_stock_wins}<span style={{ color: HEX.faint, fontSize: 12 }}>|</span>{advancedMetrics.dominance_factor.matt.three_stock_wins}</div><div style={{ fontSize: 10, color: HEX.dim }}>3-stock</div></div>
+                  <div><div style={{ fontFamily: mono, fontSize: 18, fontWeight: 700, color: HEX.fgLight }}>{advancedMetrics.two_stock_wins.shayne.two_stock_wins}<span style={{ color: HEX.faint, fontSize: 12 }}>|</span>{advancedMetrics.two_stock_wins.matt.two_stock_wins}</div><div style={{ fontSize: 10, color: HEX.dim }}>2-stock</div></div>
                 </div>
               </div>
             </div>
           </div>
 
-          {/* Dominance Stats Grid */}
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem' }}>
-            <div style={{ 
-              background: '#282828',
-              borderRadius: '10px',
-              padding: '1rem',
-              border: '1px solid #3c3836'
-            }}>
-              <div style={{ fontSize: '0.75rem', color: '#a89984', marginBottom: '0.5rem', textTransform: 'uppercase', letterSpacing: '1px' }}>
-                ⚡ 3-Stock Wins
-              </div>
-              <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
-                <span style={{ color: '#fe8019' }}>{advancedMetrics.dominance_factor.shayne.three_stock_wins}</span>
-                <span style={{ color: '#a89984', margin: '0 0.5rem' }}>|</span>
-                <span style={{ color: '#b8bb26' }}>{advancedMetrics.dominance_factor.matt.three_stock_wins}</span>
-              </div>
-            </div>
+          {/* tonight divider */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 14, margin: '26px 0' }}>
+            <div style={{ flex: 1, height: 1, background: `linear-gradient(to right,transparent,${HEX.line2})` }} />
+            <div style={{ fontFamily: mono, fontSize: 11, letterSpacing: 2, color: '#1b1817', background: `linear-gradient(135deg,${HEX.blue},${HEX.aqua})`, padding: '6px 18px', borderRadius: 20, fontWeight: 700, textTransform: 'uppercase' }}>This session</div>
+            <div style={{ flex: 1, height: 1, background: `linear-gradient(to left,transparent,${HEX.line2})` }} />
+          </div>
 
-            <div style={{ 
-              background: '#282828',
-              borderRadius: '10px',
-              padding: '1rem',
-              border: '1px solid #3c3836'
-            }}>
-              <div style={{ fontSize: '0.75rem', color: '#a89984', marginBottom: '0.5rem', textTransform: 'uppercase', letterSpacing: '1px' }}>
-                💪 2-Stock Wins
+          {/* session score + quick stats */}
+          <div style={{ display: 'grid', gridTemplateColumns: '1.5fr 1fr', gap: 16, marginBottom: 22 }}>
+            <div style={{ position: 'relative', overflow: 'hidden', borderRadius: 18, border: `1px solid ${HEX.line2}`, background: 'linear-gradient(135deg,#221f1e,#1a1716)', padding: 24, textAlign: 'center' }}>
+              <div style={{ position: 'absolute', top: '-40%', left: '-10%', width: '50%', height: '180%', background: 'radial-gradient(circle,rgba(254,128,25,0.14),transparent 62%)' }} />
+              <div style={{ position: 'absolute', top: '-40%', right: '-10%', width: '50%', height: '180%', background: 'radial-gradient(circle,rgba(184,187,38,0.14),transparent 62%)' }} />
+              <div style={{ position: 'relative' }}>
+                <div style={{ fontFamily: mono, fontSize: 10, letterSpacing: 2, color: HEX.dim, textTransform: 'uppercase', marginBottom: 12 }}>Session score</div>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 28 }}>
+                  <div><div style={{ fontFamily: mono, fontSize: 56, fontWeight: 700, color: HEX.shayne, lineHeight: 1 }}>{stats.shayne_wins}</div><div style={{ fontSize: 12, color: HEX.shayne, fontWeight: 600, marginTop: 6 }}>Shayne</div></div>
+                  <div style={{ fontFamily: mono, fontSize: 30, color: HEX.bl }}>–</div>
+                  <div><div style={{ fontFamily: mono, fontSize: 56, fontWeight: 700, color: HEX.matt, lineHeight: 1 }}>{stats.matt_wins}</div><div style={{ fontSize: 12, color: HEX.matt, fontWeight: 600, marginTop: 6 }}>Matt</div></div>
+                </div>
               </div>
-              <div style={{ fontSize: '1.2rem', fontWeight: 'bold' }}>
-                <span style={{ color: '#fe8019' }}>{advancedMetrics.two_stock_wins.shayne.two_stock_wins}</span>
-                <span style={{ color: '#a89984', margin: '0 0.5rem' }}>|</span>
-                <span style={{ color: '#b8bb26' }}>{advancedMetrics.two_stock_wins.matt.two_stock_wins}</span>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <div style={{ flex: 1, background: HEX.panel, border: `1px solid ${HEX.line}`, borderRadius: 14, padding: 16, display: 'flex', alignItems: 'center', gap: 12 }}>
+                <span style={{ fontSize: 22 }}>🔥</span>
+                <div><div style={{ fontFamily: mono, fontSize: 22, fontWeight: 700, color: streak.player === 'Shayne' ? HEX.shayne : HEX.matt, lineHeight: 1 }}>{streak.length}</div><div style={{ fontSize: 11, color: HEX.dim, marginTop: 3 }}>Current streak · {streak.player}</div></div>
+              </div>
+              <div style={{ flex: 1, background: HEX.panel, border: `1px solid ${HEX.line}`, borderRadius: 14, padding: 16 }}>
+                <div style={{ fontFamily: mono, fontSize: 10, color: HEX.dim, textTransform: 'uppercase', letterSpacing: 1, marginBottom: 8 }}>Last 10 games</div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+                  <span style={{ fontFamily: mono, fontSize: 18, fontWeight: 700, color: HEX.shayne }}>{last10.shayne_wins}</span>
+                  <span style={{ fontFamily: mono, fontSize: 18, fontWeight: 700, color: HEX.matt }}>{last10.matt_wins}</span>
+                </div>
+                <div style={{ display: 'flex', height: 6, borderRadius: 3, overflow: 'hidden' }}>
+                  <div style={{ width: `${(last10.shayne_wins / last10Total) * 100}%`, background: HEX.shayne }} />
+                  <div style={{ width: `${(last10.matt_wins / last10Total) * 100}%`, background: HEX.matt }} />
+                </div>
               </div>
             </div>
           </div>
-        </div>
 
-        {/* ========== DIVIDER ========== */}
-        <div style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: '1rem',
-          marginBottom: '2.5rem'
-        }}>
-          <div style={{ flex: 1, height: '2px', background: 'linear-gradient(to right, transparent, #504945, transparent)' }} />
-          <div style={{ 
-            background: 'linear-gradient(135deg, #83a598, #8ec07c)',
-            color: '#282828',
-            padding: '0.6rem 2rem',
-            borderRadius: '25px',
-            fontSize: '0.9rem',
-            fontWeight: 'bold',
-            textTransform: 'uppercase',
-            letterSpacing: '2px',
-            boxShadow: '0 4px 12px rgba(131, 165, 152, 0.3)',
-            border: '2px solid #a3c0b8'
-          }}>
-            📅 Today's Session
-          </div>
-          <div style={{ flex: 1, height: '2px', background: 'linear-gradient(to left, transparent, #504945, transparent)' }} />
-        </div>
-
-        {/* Hero Stats */}
-        <div style={{ 
-          background: 'linear-gradient(135deg, #3c3836 0%, #282828 100%)',
-          borderRadius: '16px',
-          padding: '2rem',
-          marginBottom: '2rem',
-          border: '2px solid #504945',
-          textAlign: 'center'
-        }}>
-          <div style={{ 
-            fontSize: '0.9rem', 
-            color: '#a89984', 
-            marginBottom: '1rem',
-            textTransform: 'uppercase',
-            letterSpacing: '2px',
-            fontWeight: 'bold'
-          }}>
-            Session Score
-          </div>
-          <div style={{ 
-            display: 'flex', 
-            justifyContent: 'center', 
-            alignItems: 'center',
-            gap: '3rem'
-          }}>
-            <div>
-              <div style={{ 
-                fontSize: '4rem', 
-                fontWeight: 'bold', 
-                color: '#fe8019',
-                lineHeight: 1,
-                textShadow: '3px 3px 6px rgba(0,0,0,0.4)'
-              }}>
-                {stats.shayne_wins}
-              </div>
-              <div style={{ 
-                fontSize: '1.2rem', 
-                color: '#fe8019',
-                marginTop: '0.5rem',
-                fontWeight: 'bold'
-              }}>
-                Shayne
-              </div>
-            </div>
-            <div style={{ 
-              fontSize: '3rem', 
-              color: '#504945',
-              fontWeight: 'bold'
-            }}>
-              -
-            </div>
-            <div>
-              <div style={{ 
-                fontSize: '4rem', 
-                fontWeight: 'bold', 
-                color: '#b8bb26',
-                lineHeight: 1,
-                textShadow: '3px 3px 6px rgba(0,0,0,0.4)'
-              }}>
-                {stats.matt_wins}
-              </div>
-              <div style={{ 
-                fontSize: '1.2rem', 
-                color: '#b8bb26',
-                marginTop: '0.5rem',
-                fontWeight: 'bold'
-              }}>
-                Matt
-              </div>
-            </div>
-          </div>
-          <div style={{ 
-            fontSize: '1rem', 
-            color: '#a89984',
-            marginTop: '1.5rem',
-            fontWeight: '500'
-          }}>
-            {stats.total_games} games played
-          </div>
-        </div>
-
-        {/* Quick Stats Grid */}
-        <div style={{ 
-          display: 'grid', 
-          gridTemplateColumns: 'repeat(2, 1fr)', 
-          gap: '1rem', 
-          marginBottom: '2rem' 
-        }}>
-          <div style={{ 
-            background: '#3c3836',
-            borderRadius: '12px',
-            padding: '1.5rem',
-            border: '1px solid #504945'
-          }}>
-            <div style={{ 
-              fontSize: '0.85rem', 
-              color: '#a89984', 
-              marginBottom: '0.75rem',
-              textTransform: 'uppercase',
-              letterSpacing: '1px'
-            }}>
-              🔥 Current Streak
-            </div>
-            <div style={{ 
-              fontSize: '2.5rem', 
-              fontWeight: 'bold',
-              color: headToHead.streaks.current_streak.player === 'Shayne' ? '#fe8019' : '#b8bb26',
-              lineHeight: 1
-            }}>
-              {headToHead.streaks.current_streak.length}
-            </div>
-            <div style={{ 
-              fontSize: '1rem', 
-              color: headToHead.streaks.current_streak.player === 'Shayne' ? '#fe8019' : '#b8bb26',
-              marginTop: '0.5rem',
-              fontWeight: 'bold'
-            }}>
-              {headToHead.streaks.current_streak.player}
-            </div>
-          </div>
-          
-          <div style={{ 
-            background: '#3c3836',
-            borderRadius: '12px',
-            padding: '1.5rem',
-            border: '1px solid #504945'
-          }}>
-            <div style={{ 
-              fontSize: '0.85rem', 
-              color: '#a89984', 
-              marginBottom: '0.75rem',
-              textTransform: 'uppercase',
-              letterSpacing: '1px'
-            }}>
-              📊 Last 10 Games
-            </div>
-            <div style={{ 
-              fontSize: '1.5rem', 
-              fontWeight: 'bold',
-              marginBottom: '0.75rem'
-            }}>
-              <span style={{ color: '#fe8019' }}>{headToHead.recent_form.last_10.shayne_wins}</span>
-              <span style={{ color: '#a89984', margin: '0 0.5rem' }}>-</span>
-              <span style={{ color: '#b8bb26' }}>{headToHead.recent_form.last_10.matt_wins}</span>
-            </div>
-            <div style={{ 
-              height: '6px', 
-              background: '#282828', 
-              borderRadius: '3px', 
-              overflow: 'hidden',
-              display: 'flex'
-            }}>
-              <div style={{ 
-                width: `${(headToHead.recent_form.last_10.shayne_wins / headToHead.recent_form.last_10.total_games) * 100}%`,
-                background: '#fe8019'
-              }}></div>
-              <div style={{ 
-                width: `${(headToHead.recent_form.last_10.matt_wins / headToHead.recent_form.last_10.total_games) * 100}%`,
-                background: '#b8bb26'
-              }}></div>
-            </div>
-          </div>
-        </div>
-
-        {/* Today's Matchups */}
-        {stats.matchup_stats && stats.matchup_stats.length > 0 && (
-          <div style={{ marginBottom: '2rem' }}>
-            <h3 style={{ 
-              fontSize: '1.2rem', 
-              marginBottom: '1rem', 
-              color: '#fbf1c7',
-              fontWeight: 'bold'
-            }}>
-              Today's Matchups
-            </h3>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-              {stats.matchup_stats.map((matchup, idx) => (
-                <div 
-                  key={idx}
-                  style={{
-                    background: '#3c3836',
-                    borderRadius: '10px',
-                    padding: '1rem',
-                    border: '1px solid #504945',
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center'
-                  }}
-                >
-                  <div style={{ flex: 1 }}>
-                    <div style={{ 
-                      fontSize: '1rem',
-                      fontWeight: 'bold',
-                      marginBottom: '0.5rem',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '0.75rem'
-                    }}>
-                      <span style={{ color: '#fe8019' }}>
-                        <CharacterDisplay character={matchup.shayne_character} />
-                      </span>
-                      <span style={{ color: '#a89984', fontSize: '0.85rem' }}>vs</span>
-                      <span style={{ color: '#b8bb26' }}>
-                        <CharacterDisplay character={matchup.matt_character} />
-                      </span>
+          {/* tonight's matchups */}
+          {stats.matchup_stats.length > 0 && (
+            <div style={{ marginBottom: 22 }}>
+              <div style={{ fontSize: 14, fontWeight: 700, color: HEX.fgLight, marginBottom: 12, fontFamily: display }}>This session's matchups</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 9 }}>
+                {stats.matchup_stats.map((m, idx) => (
+                  <div key={idx} style={{ background: HEX.panel, border: `1px solid ${HEX.line}`, borderRadius: 10, padding: '12px 16px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <div>
+                      <div style={{ fontSize: 14, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
+                        <span style={{ color: HEX.shayne }}><CharacterDisplay character={m.shayne_character} /></span>
+                        <span style={{ color: HEX.faint, fontSize: 12 }}>vs</span>
+                        <span style={{ color: HEX.matt }}><CharacterDisplay character={m.matt_character} /></span>
+                      </div>
+                      <div style={{ fontFamily: mono, fontSize: 10, color: HEX.dim, marginTop: 2 }}>{m.total_games} {m.total_games === 1 ? 'game' : 'games'}</div>
                     </div>
-                    <div style={{ fontSize: '0.75rem', color: '#a89984' }}>
-                      {matchup.total_games} {matchup.total_games === 1 ? 'game' : 'games'} played
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+                      <span style={{ fontFamily: mono, fontSize: 20, fontWeight: 700, color: HEX.shayne }}>{m.shayne_wins}</span>
+                      <span style={{ fontFamily: mono, fontSize: 14, color: HEX.bl }}>–</span>
+                      <span style={{ fontFamily: mono, fontSize: 20, fontWeight: 700, color: HEX.matt }}>{m.matt_wins}</span>
                     </div>
                   </div>
-                  <div style={{ 
-                    display: 'flex',
-                    gap: '1.5rem',
-                    alignItems: 'center'
-                  }}>
-                    <div style={{ textAlign: 'center' }}>
-                      <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#fe8019' }}>
-                        {matchup.shayne_wins}
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* character usage */}
+          {(Object.keys(stats.shayne_characters).length > 0 || Object.keys(stats.matt_characters).length > 0) && (
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 22 }}>
+              {([['Shayne', stats.shayne_characters, HEX.shayne], ['Matt', stats.matt_characters, HEX.matt]] as const).map(([name, usage, color]) => (
+                <div key={name} style={{ background: HEX.panel, border: `1px solid ${HEX.line}`, borderRadius: 14, padding: 18 }}>
+                  <div style={{ fontSize: 13, fontWeight: 700, color, marginBottom: 12 }}>{name} played</div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {Object.entries(usage).sort(([, a], [, b]) => b - a).slice(0, 4).map(([char, count]) => (
+                      <div key={char} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 11px', background: HEX.card, borderRadius: 8 }}>
+                        <span style={{ fontSize: 13, color: HEX.fg }}><CharacterDisplay character={char} /></span>
+                        <span style={{ fontFamily: mono, fontSize: 15, fontWeight: 700, color }}>{count}</span>
                       </div>
-                      <div style={{ fontSize: '0.7rem', color: '#a89984' }}>Shayne</div>
-                    </div>
-                    <div style={{ fontSize: '1.2rem', color: '#504945' }}>-</div>
-                    <div style={{ textAlign: 'center' }}>
-                      <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#b8bb26' }}>
-                        {matchup.matt_wins}
-                      </div>
-                      <div style={{ fontSize: '0.7rem', color: '#a89984' }}>Matt</div>
-                    </div>
+                    ))}
                   </div>
                 </div>
               ))}
             </div>
-          </div>
-        )}
+          )}
 
-        {/* Character Usage */}
-        {(Object.keys(stats.shayne_characters).length > 0 || Object.keys(stats.matt_characters).length > 0) && (
-          <div style={{ marginBottom: '2rem' }}>
-            <h3 style={{ 
-              fontSize: '1.2rem', 
-              marginBottom: '1rem', 
-              color: '#fbf1c7',
-              fontWeight: 'bold'
-            }}>
-              Character Usage
-            </h3>
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
-              <div style={{ 
-                background: '#3c3836',
-                borderRadius: '12px',
-                padding: '1.25rem',
-                border: '1px solid #504945'
-              }}>
-                <div style={{ 
-                  fontSize: '1rem', 
-                  color: '#fe8019',
-                  marginBottom: '1rem',
-                  fontWeight: 'bold'
-                }}>
-                  Shayne
-                </div>
-                {Object.entries(stats.shayne_characters)
-                  .sort(([,a],[,b])=>b-a)
-                  .slice(0, 5)
-                  .map(([char, count]) => (
-                    <div 
-                      key={char}
-                      style={{ 
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                        marginBottom: '0.75rem',
-                        padding: '0.5rem',
-                        background: '#282828',
-                        borderRadius: '6px'
-                      }}
-                    >
-                      <div style={{ fontSize: '0.95rem' }}>
-                        <CharacterDisplay character={char} />
-                      </div>
-                      <span style={{ 
-                        fontSize: '1.1rem',
-                        fontWeight: 'bold',
-                        color: '#fe8019'
-                      }}>
-                        {count}
-                      </span>
-                    </div>
-                  ))}
-              </div>
-              <div style={{ 
-                background: '#3c3836',
-                borderRadius: '12px',
-                padding: '1.25rem',
-                border: '1px solid #504945'
-              }}>
-                <div style={{ 
-                  fontSize: '1rem', 
-                  color: '#b8bb26',
-                  marginBottom: '1rem',
-                  fontWeight: 'bold'
-                }}>
-                  Matt
-                </div>
-                {Object.entries(stats.matt_characters)
-                  .sort(([,a],[,b])=>b-a)
-                  .slice(0, 5)
-                  .map(([char, count]) => (
-                    <div 
-                      key={char}
-                      style={{ 
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                        marginBottom: '0.75rem',
-                        padding: '0.5rem',
-                        background: '#282828',
-                        borderRadius: '6px'
-                      }}
-                    >
-                      <div style={{ fontSize: '0.95rem' }}>
-                        <CharacterDisplay character={char} />
-                      </div>
-                      <span style={{ 
-                        fontSize: '1.1rem',
-                        fontWeight: 'bold',
-                        color: '#b8bb26'
-                      }}>
-                        {count}
-                      </span>
-                    </div>
-                  ))}
+          {/* stage breakdown */}
+          {stats.stage_stats.length > 0 && (
+            <div style={{ marginBottom: 22 }}>
+              <div style={{ fontSize: 14, fontWeight: 700, color: HEX.fgLight, marginBottom: 12, fontFamily: display }}>Stage breakdown</div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 10 }}>
+                {stats.stage_stats.slice(0, 4).map((st) => (
+                  <div key={st.stage} style={{ position: 'relative', overflow: 'hidden', borderRadius: 12, border: `1px solid ${HEX.line2}`, minHeight: 88, display: 'flex', flexDirection: 'column', justifyContent: 'space-between', padding: 12, backgroundImage: stageImages[st.stage] ? `url(${stageImages[st.stage]})` : 'none', backgroundSize: 'cover', backgroundPosition: 'center' }}>
+                    <div style={{ position: 'absolute', inset: 0, background: 'rgba(12,10,9,0.58)' }} />
+                    <div style={{ position: 'relative', fontSize: 11, color: HEX.fgLight, fontWeight: 600, textShadow: '0 2px 4px rgba(0,0,0,0.9)' }}>{st.stage}</div>
+                    <div style={{ position: 'relative', fontFamily: mono, fontSize: 24, fontWeight: 700, color: HEX.blue, textShadow: '0 2px 4px rgba(0,0,0,0.9)' }}>{st.count}</div>
+                  </div>
+                ))}
               </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {/* Stage Stats */}
-        {stats.stage_stats.length > 0 && (
-          <div style={{ marginBottom: '2rem' }}>
-            <h3 style={{ 
-              fontSize: '1.2rem', 
-              marginBottom: '1rem', 
-              color: '#fbf1c7',
-              fontWeight: 'bold'
-            }}>
-              Stage Breakdown
-            </h3>
-            <div style={{ 
-              display: 'grid', 
-              gridTemplateColumns: 'repeat(3, 1fr)', 
-              gap: '0.75rem' 
-            }}>
-              {stats.stage_stats.slice(0, 6).map(stat => (
-                <div 
-                  key={stat.stage}
-                  style={{
-                    backgroundImage: stageImages[stat.stage] ? `url(${stageImages[stat.stage]})` : 'none',
-                    backgroundSize: 'cover',
-                    backgroundPosition: 'center',
-                    borderRadius: '12px',
-                    padding: '1rem',
-                    minHeight: '80px',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'space-between',
-                    position: 'relative',
-                    overflow: 'hidden',
-                    border: '2px solid #504945'
-                  }}
-                >
-                  <div style={{
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
-                    right: 0,
-                    bottom: 0,
-                    backgroundColor: 'rgba(0, 0, 0, 0.65)',
-                    zIndex: 1,
-                  }} />
-                  <div style={{ 
-                    position: 'relative',
-                    zIndex: 2,
-                    fontSize: '0.85rem',
-                    color: '#fbf1c7',
-                    fontWeight: 'bold',
-                    textShadow: '0 2px 4px rgba(0,0,0,0.9)'
-                  }}>
-                    {stat.stage}
-                  </div>
-                  <div style={{ 
-                    position: 'relative',
-                    zIndex: 2,
-                    fontSize: '1.8rem',
-                    fontWeight: 'bold',
-                    color: '#83a598',
-                    textShadow: '0 2px 4px rgba(0,0,0,0.9)'
-                  }}>
-                    {stat.count}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Recent Games */}
-        {recentGames.length > 0 && (
-          <div>
-            <h3 style={{ 
-              fontSize: '1.2rem', 
-              marginBottom: '1rem', 
-              color: '#fbf1c7',
-              fontWeight: 'bold'
-            }}>
-              Recent Games
-            </h3>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-              {recentGames.slice(0, 8).map((game, idx) => {
-                const isShayneWin = game.winner === 'Shayne';
-                return (
-                  <div 
-                    key={idx}
-                    style={{
-                      background: '#3c3836',
-                      borderRadius: '10px',
-                      padding: '0.9rem',
-                      border: '1px solid #504945',
-                      borderLeft: `4px solid ${isShayneWin ? '#fe8019' : '#b8bb26'}`,
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center'
-                    }}
-                  >
-                    <div style={{ flex: 1 }}>
-                      <div style={{ 
-                        fontSize: '0.95rem',
-                        fontWeight: '600',
-                        color: '#fbf1c7',
-                        marginBottom: '0.3rem',
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '0.5rem'
-                      }}>
-                        <CharacterDisplay character={game.shayne_character} />
-                        <span style={{ color: '#a89984', fontSize: '0.8rem' }}>vs</span>
-                        <CharacterDisplay character={game.matt_character} />
+          {/* recent games */}
+          {recentGames.length > 0 && (
+            <div>
+              <div style={{ fontSize: 14, fontWeight: 700, color: HEX.fgLight, marginBottom: 12, fontFamily: display }}>Recent games</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {recentGames.slice(0, 7).map((game, idx) => {
+                  const isShayneWin = game.winner === 'Shayne';
+                  const accent = isShayneWin ? HEX.shayne : HEX.matt;
+                  return (
+                    <div key={idx} style={{ background: HEX.panel, border: `1px solid ${HEX.line}`, borderLeft: `4px solid ${accent}`, borderRadius: 10, padding: '11px 14px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                      <div style={{ minWidth: 0 }}>
+                        <div style={{ fontSize: 14, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
+                          <span style={{ color: HEX.shayne }}><CharacterDisplay character={game.shayne_character} /></span>
+                          <span style={{ color: HEX.faint, fontSize: 11 }}>vs</span>
+                          <span style={{ color: HEX.matt }}><CharacterDisplay character={game.matt_character} /></span>
+                        </div>
+                        <div style={{ fontFamily: mono, fontSize: 10, color: HEX.dim, marginTop: 2 }}>{formatTime(game.datetime)} · {game.stage}</div>
                       </div>
-                      <div style={{ 
-                        fontSize: '0.75rem',
-                        color: '#a89984',
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '0.5rem'
-                      }}>
-                        <span>{formatTime(game.datetime)}</span>
-                        <span>•</span>
-                        <span>{game.stage}</span>
+                      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 5 }}>
+                        <span style={{ fontFamily: mono, fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.5px', color: accent }}>{game.winner}</span>
+                        <div style={{ display: 'flex', gap: 4 }}>
+                          {[...Array(Math.max(0, game.stocks_remaining || 0))].map((_, i) => (
+                            <div key={i} style={{ width: 8, height: 8, borderRadius: '50%', background: accent }} />
+                          ))}
+                        </div>
                       </div>
                     </div>
-                    <div style={{ 
-                      textAlign: 'right',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'flex-end',
-                      gap: '0.3rem'
-                    }}>
-                      <div style={{ 
-                        fontSize: '0.85rem',
-                        fontWeight: 'bold',
-                        color: isShayneWin ? '#fe8019' : '#b8bb26',
-                        textTransform: 'uppercase',
-                        letterSpacing: '0.5px'
-                      }}>
-                        {game.winner}
-                      </div>
-                      <div style={{ 
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '0.25rem'
-                      }}>
-                        {[...Array(game.stocks_remaining)].map((_, i) => (
-                          <div key={i} style={{ 
-                            width: '8px',
-                            height: '8px',
-                            borderRadius: '50%',
-                            background: isShayneWin ? '#fe8019' : '#b8bb26'
-                          }} />
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                );
-              })}
+                  );
+                })}
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {/* Footer */}
-        <div style={{ 
-          marginTop: '2rem',
-          paddingTop: '1.5rem',
-          borderTop: '2px solid #504945',
-          textAlign: 'center',
-          fontSize: '0.85rem',
-          color: '#a89984'
-        }}>
-          Generated by Smash Match Logger
+          {/* footer */}
+          <div style={{ marginTop: 26, paddingTop: 18, borderTop: `1px solid ${HEX.line}`, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <span style={{ fontSize: 16, fontWeight: 700, color: HEX.fgLight, fontFamily: display }}>Smash<span style={{ color: HEX.shayne }}>Log</span></span>
+            <span style={{ fontFamily: mono, fontSize: 11, color: HEX.faint }}>Smash Match Logger</span>
+          </div>
         </div>
       </div>
     </div>
@@ -1045,4 +483,3 @@ function SessionTearsheet() {
 }
 
 export default SessionTearsheet;
-

--- a/frontend/src/StatsPage.tsx
+++ b/frontend/src/StatsPage.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import CharacterDisplay from './components/CharacterDisplay';
-import { BarChart, Bar, XAxis, YAxis, Tooltip } from './components/dither';
+import { AreaChart, Area, BarChart, Bar, XAxis, YAxis, Tooltip, PieChart, Pie, DitherHeatmap, Grid, type DitherHeatmapCell } from './components/dither';
+import { LoadingState, ErrorState } from './components/Feedback';
+import { PageColumn, PageHeader, SectionTitle, Card, GlowPanel, StatTile } from './components/ui';
+import { SplitBar } from './session/components/bars';
 
 // ===== TYPE DEFINITIONS =====
 interface MonthlyActivityItem {
@@ -119,14 +122,67 @@ interface MatchupMatrix {
     matt_win_rate: number;
   }>;
   best_matchups: {
-    shayne: Array<any>;
-    matt: Array<any>;
+    shayne: Array<unknown>;
+    matt: Array<unknown>;
   };
   worst_matchups: {
-    shayne: Array<any>;
-    matt: Array<any>;
+    shayne: Array<unknown>;
+    matt: Array<unknown>;
   };
 }
+
+interface UserStageStat {
+  stage: string;
+  winRate: number;
+  totalGames: number;
+  wins: number;
+  losses: number;
+}
+
+interface HeatmapCell {
+  hour: number;
+  day: number;
+  win_rate: number;
+  game_count: number;
+}
+
+const TOOLTIPS: Record<string, { title: string; body: React.ReactNode }> = {
+  close: {
+    title: '1-Stock Victory Percentages',
+    body: (
+      <>
+        <div style={{ marginBottom: '0.3rem' }}><span style={{ color: 'var(--blue)', fontWeight: 700 }}>First %:</span> of this player's wins, what % were 1-stock victories</div>
+        <div><span style={{ color: 'var(--blue)', fontWeight: 700 }}>Second %:</span> of all games, what % were 1-stock victories for this player</div>
+      </>
+    ),
+  },
+  two: {
+    title: '2-Stock Victory Percentages',
+    body: (
+      <>
+        <div style={{ marginBottom: '0.3rem' }}><span style={{ color: 'var(--blue)', fontWeight: 700 }}>First %:</span> of this player's wins, what % were 2-stock victories</div>
+        <div><span style={{ color: 'var(--blue)', fontWeight: 700 }}>Second %:</span> of all games, what % were 2-stock victories for this player</div>
+      </>
+    ),
+  },
+  three: {
+    title: '3-Stock Victory Percentages',
+    body: (
+      <>
+        <div style={{ marginBottom: '0.3rem' }}><span style={{ color: 'var(--blue)', fontWeight: 700 }}>First %:</span> of this player's wins, what % were 3-stock victories</div>
+        <div><span style={{ color: 'var(--blue)', fontWeight: 700 }}>Second %:</span> of all games, what % were 3-stock victories for this player</div>
+      </>
+    ),
+  },
+  momentum: {
+    title: 'Momentum',
+    body: 'The share of games won immediately after winning the previous game. Higher values mean a stronger ability to maintain winning streaks.',
+  },
+  consistency: {
+    title: 'Consistency',
+    body: 'Win-rate volatility — the standard deviation of performance across rolling 20-game windows. Lower is steadier.',
+  },
+};
 
 // ===== MAIN COMPONENT =====
 const StatsPage: React.FC = () => {
@@ -135,50 +191,66 @@ const StatsPage: React.FC = () => {
   const [headToHead, setHeadToHead] = useState<HeadToHeadStats | null>(null);
   const [advancedMetrics, setAdvancedMetrics] = useState<AdvancedMetrics | null>(null);
   const [matchupMatrix, setMatchupMatrix] = useState<MatchupMatrix | null>(null);
+  const [stageStats, setStageStats] = useState<UserStageStat[]>([]);
+  const [heatmap, setHeatmap] = useState<HeatmapCell[]>([]);
+  const [winTimeline, setWinTimeline] = useState<number[]>([]);
+  const [sessionCount, setSessionCount] = useState<number>(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTooltip, setActiveTooltip] = useState<string | null>(null);
-  
-  useEffect(() => {
-    const fetchStats = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const [statsRes, charRes, h2hRes, advRes, matchupRes] = await Promise.all([
-          fetch('/api/stats'),
-          fetch('/api/character_win_rates'),
-          fetch('/api/head_to_head_stats'),
-          fetch('/api/advanced_metrics'),
-          fetch('/api/matchup_matrix'),
-        ]);
-        
-        const statsData = await statsRes.json();
-        const charData = await charRes.json();
-        const h2hData = await h2hRes.json();
-        const advData = await advRes.json();
-        const matchupData = await matchupRes.json();
-        
-        if (!statsData.success) throw new Error(statsData.message || 'Failed to load stats');
-        if (!charData.success) throw new Error(charData.message || 'Failed to load character win rates');
-        if (!h2hData.success) throw new Error(h2hData.message || 'Failed to load head-to-head stats');
-        if (!advData.success) throw new Error(advData.message || 'Failed to load advanced metrics');
-        if (!matchupData.success) throw new Error(matchupData.message || 'Failed to load matchup matrix');
-        
-        setStats(statsData.stats);
-        setCharWinRates(charData);
-        setHeadToHead(h2hData);
-        setAdvancedMetrics(advData);
-        setMatchupMatrix(matchupData);
-      } catch (err: any) {
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchStats();
+
+  const fetchStats = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [statsRes, charRes, h2hRes, advRes, matchupRes, userRes, heatRes, tlRes, sessRes] = await Promise.all([
+        fetch('/api/stats'),
+        fetch('/api/character_win_rates'),
+        fetch('/api/head_to_head_stats'),
+        fetch('/api/advanced_metrics'),
+        fetch('/api/matchup_matrix'),
+        fetch('/api/users/Shayne/stats'),
+        fetch('/api/users/Shayne/heatmap'),
+        fetch('/api/users/Shayne/win-rate-timeline'),
+        fetch('/api/sessions'),
+      ]);
+
+      const statsData = await statsRes.json();
+      const charData = await charRes.json();
+      const h2hData = await h2hRes.json();
+      const advData = await advRes.json();
+      const matchupData = await matchupRes.json();
+      const userData = await userRes.json().catch(() => null);
+      const heatData = await heatRes.json().catch(() => null);
+      const tlData = await tlRes.json().catch(() => null);
+      const sessData = await sessRes.json().catch(() => null);
+
+      if (!statsData.success) throw new Error(statsData.message || 'Failed to load stats');
+      if (!charData.success) throw new Error(charData.message || 'Failed to load character win rates');
+      if (!h2hData.success) throw new Error(h2hData.message || 'Failed to load head-to-head stats');
+      if (!advData.success) throw new Error(advData.message || 'Failed to load advanced metrics');
+      if (!matchupData.success) throw new Error(matchupData.message || 'Failed to load matchup matrix');
+
+      setStats(statsData.stats);
+      setCharWinRates(charData);
+      setHeadToHead(h2hData);
+      setAdvancedMetrics(advData);
+      setMatchupMatrix(matchupData);
+      setStageStats(userData?.stageStats ?? []);
+      setHeatmap(heatData?.data ?? []);
+      setWinTimeline(tlData?.data?.win_rates ?? []);
+      setSessionCount(sessData?.sessions?.length ?? 0);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load statistics');
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  // Initialize eCharts chart for monthly activity
+  useEffect(() => {
+    fetchStats();
+  }, [fetchStats]);
+
   const monthlyChartData = stats
     ? stats.monthly_activity.map(item => {
         const [year, month] = item.month.split('-');
@@ -187,8 +259,8 @@ const StatsPage: React.FC = () => {
       })
     : [];
 
-  if (loading) return <div className="stats-container"><div style={{ textAlign: 'center', padding: '3rem', fontSize: '1.2rem' }}>Loading statistics...</div></div>;
-  if (error) return <div className="stats-container"><div className="error" style={{ textAlign: 'center', padding: '2rem' }}>{error}</div></div>;
+  if (loading) return <LoadingState label="Loading statistics…" />;
+  if (error) return <ErrorState message={error} onRetry={fetchStats} />;
   if (!stats || !charWinRates || !headToHead || !advancedMetrics || !matchupMatrix) return null;
 
   const getTop5 = (data: CharacterWinRates) =>
@@ -196,591 +268,302 @@ const StatsPage: React.FC = () => {
       .sort((a, b) => b[1].total - a[1].total)
       .slice(0, 5);
 
+  const longestStreak = Math.max(
+    headToHead.streaks.longest_win_streaks.Shayne.length,
+    headToHead.streaks.longest_win_streaks.Matt.length,
+  );
+  const margin = Math.abs(stats.shayne_wins - stats.matt_wins);
+
+  // Merged character win-rate bars (top by games, both players).
+  const mergedChars = [
+    ...Object.entries(charWinRates.shayne).map(([c, s]) => ({ character: c, player: 'Shayne' as const, ...s })),
+    ...Object.entries(charWinRates.matt).map(([c, s]) => ({ character: c, player: 'Matt' as const, ...s })),
+  ]
+    .filter((c) => c.total >= 10)
+    .sort((a, b) => b.total - a.total)
+    .slice(0, 8);
+
+  const heatCells: DitherHeatmapCell[] = heatmap.map((c) => ({
+    day: c.day,
+    hour: c.hour,
+    winRate: c.game_count > 0 ? c.win_rate : null,
+    games: c.game_count,
+  }));
+
+  const timelineData = winTimeline.map((wr, i) => ({ i, wr }));
+
+  const metricCards = [
+    { key: 'close', emoji: '⚔️', label: 'Close games', sub: '1-stock victories', s: advancedMetrics.close_game_record.shayne.wins, m: advancedMetrics.close_game_record.matt.wins, sSub: `${advancedMetrics.close_game_record.shayne.win_rate}% · ${advancedMetrics.close_game_record.shayne.of_all_games}%`, mSub: `${advancedMetrics.close_game_record.matt.win_rate}% · ${advancedMetrics.close_game_record.matt.of_all_games}%` },
+    { key: 'two', emoji: '💪', label: 'Solid wins', sub: '2-stock victories', s: advancedMetrics.two_stock_wins.shayne.two_stock_wins, m: advancedMetrics.two_stock_wins.matt.two_stock_wins, sSub: `${advancedMetrics.two_stock_wins.shayne.two_stock_rate}% · ${advancedMetrics.two_stock_wins.shayne.of_all_games}%`, mSub: `${advancedMetrics.two_stock_wins.matt.two_stock_rate}% · ${advancedMetrics.two_stock_wins.matt.of_all_games}%` },
+    { key: 'three', emoji: '⚡', label: 'Dominance', sub: '3-stock wins', s: advancedMetrics.dominance_factor.shayne.three_stock_wins, m: advancedMetrics.dominance_factor.matt.three_stock_wins, sSub: `${advancedMetrics.dominance_factor.shayne.dominance_rate}% · ${advancedMetrics.dominance_factor.shayne.of_all_games}%`, mSub: `${advancedMetrics.dominance_factor.matt.dominance_rate}% · ${advancedMetrics.dominance_factor.matt.of_all_games}%` },
+    { key: 'avg', emoji: '🎯', label: 'Avg stocks left', sub: 'when winning', s: headToHead.avg_stock_differential.shayne, m: headToHead.avg_stock_differential.matt },
+    { key: 'momentum', emoji: '📈', label: 'Momentum', sub: 'win after win', s: `${advancedMetrics.momentum_analysis.shayne.win_after_win}%`, m: `${advancedMetrics.momentum_analysis.matt.win_after_win}%` },
+    { key: 'consistency', emoji: '📊', label: 'Consistency', sub: 'lower is steadier', s: advancedMetrics.consistency_score.shayne, m: advancedMetrics.consistency_score.matt },
+  ];
+
   return (
-    <div className="stats-container" style={{ maxWidth: '1400px', padding: '1.5rem', gap: '1.5rem' }}>
-      
-      {/* HERO SECTION - Compact Overview */}
-      <section className="stats-section" style={{ marginBottom: '1rem' }}>
-        <div style={{ 
-          background: 'linear-gradient(135deg, #3c3836 0%, #282828 100%)',
-          borderRadius: '16px',
-          padding: '1.5rem',
-          border: '1px solid #504945',
-          boxShadow: '0 4px 12px rgba(0,0,0,0.3)'
-        }}>
-          <div style={{ 
-            display: 'grid', 
-            gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', 
-            gap: '1rem',
-            marginBottom: '1rem'
-          }}>
-            <div style={{ textAlign: 'center' }}>
-              <div style={{ fontSize: '0.75rem', color: '#a89984', marginBottom: '0.25rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>Total Games</div>
-              <div style={{ fontSize: '2rem', fontWeight: 'bold', color: '#83a598' }}>{stats.total_games}</div>
+    <PageColumn>
+      <PageHeader title="Statistics" subtitle="Shayne vs Matt · all-time" />
+
+      {/* H2H hero */}
+      <GlowPanel style={{ padding: '28px 32px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 36, flexWrap: 'wrap' }}>
+          <div style={{ position: 'relative', width: 128, height: 128, flex: '0 0 auto' }}>
+            <PieChart
+              data={[{ player: 'Shayne', wins: stats.shayne_wins }, { player: 'Matt', wins: stats.matt_wins }]}
+              config={{ Shayne: { label: 'Shayne', color: 'orange' }, Matt: { label: 'Matt', color: 'green' } }}
+              dataKey="wins"
+              nameKey="player"
+              innerRadius={0.68}
+            >
+              <Pie variant="gradient" />
+            </PieChart>
+            <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', pointerEvents: 'none' }}>
+              <span style={{ fontFamily: 'var(--font-mono)', fontSize: 18, fontWeight: 700, color: 'var(--fg-light)' }}>{stats.shayne_win_rate}%</span>
+              <span style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--gray)', letterSpacing: 1 }}>SHAYNE</span>
             </div>
-            <div style={{ textAlign: 'center' }}>
-              <div style={{ fontSize: '0.75rem', color: '#a89984', marginBottom: '0.25rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>Shayne</div>
-              <div style={{ fontSize: '2rem', fontWeight: 'bold', color: '#fe8019' }}>{stats.shayne_wins}</div>
-              <div style={{ fontSize: '0.8rem', color: '#fe8019', opacity: 0.8 }}>{stats.shayne_win_rate}%</div>
+          </div>
+          <div style={{ flex: 1, minWidth: 200 }}>
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--gray)', letterSpacing: 2, marginBottom: 8 }}>ALL-TIME RECORD</div>
+            <div style={{ fontFamily: 'var(--font-mono)', fontSize: 52, fontWeight: 700, lineHeight: 1 }}>
+              <span style={{ color: 'var(--shayne)' }}>{stats.shayne_wins}</span>
+              <span style={{ color: 'var(--border-light)' }}>–</span>
+              <span style={{ color: 'var(--matt)' }}>{stats.matt_wins}</span>
             </div>
-            <div style={{ textAlign: 'center' }}>
-              <div style={{ fontSize: '0.75rem', color: '#a89984', marginBottom: '0.25rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>Matt</div>
-              <div style={{ fontSize: '2rem', fontWeight: 'bold', color: '#b8bb26' }}>{stats.matt_wins}</div>
-              <div style={{ fontSize: '0.8rem', color: '#b8bb26', opacity: 0.8 }}>{stats.matt_win_rate}%</div>
-            </div>
-            <div style={{ textAlign: 'center' }}>
-              <div style={{ fontSize: '0.75rem', color: '#a89984', marginBottom: '0.25rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>Current Streak</div>
-              <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: stats.current_streak?.player === 'Shayne' ? '#fe8019' : '#b8bb26' }}>
-                {stats.current_streak?.length || 0}
-              </div>
-              <div style={{ fontSize: '0.75rem', color: '#a89984' }}>{stats.current_streak?.player || 'None'}</div>
-            </div>
-            <div style={{ textAlign: 'center' }}>
-              <div style={{ fontSize: '0.75rem', color: '#a89984', marginBottom: '0.25rem', textTransform: 'uppercase', letterSpacing: '0.5px' }}>This Week</div>
-              <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#d3869b' }}>{stats.games_this_week}</div>
-              <div style={{ fontSize: '0.75rem', color: '#a89984' }}>games</div>
+            <div style={{ display: 'flex', gap: 24, marginTop: 14, flexWrap: 'wrap' }}>
+              <div><div style={{ fontSize: 13, color: 'var(--shayne)', fontWeight: 600 }}>Shayne {stats.shayne_win_rate}%</div><div style={{ fontSize: 11, color: 'var(--gray)', fontFamily: 'var(--font-mono)', marginTop: 2 }}>{stats.shayne_wins} wins</div></div>
+              <div><div style={{ fontSize: 13, color: 'var(--matt)', fontWeight: 600 }}>Matt {stats.matt_win_rate}%</div><div style={{ fontSize: 11, color: 'var(--gray)', fontFamily: 'var(--font-mono)', marginTop: 2 }}>{stats.matt_wins} wins</div></div>
+              <div><div style={{ fontSize: 13, color: 'var(--fg)', fontWeight: 600 }}>+{margin}</div><div style={{ fontSize: 11, color: 'var(--gray)', fontFamily: 'var(--font-mono)', marginTop: 2 }}>margin</div></div>
             </div>
           </div>
         </div>
-      </section>
+      </GlowPanel>
 
-      {/* RECENT FORM - Compact Cards */}
-      <section className="stats-section">
-        <h2 style={{ fontSize: '1.3rem', marginBottom: '0.75rem', color: '#fbf1c7' }}>Recent Form</h2>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '0.75rem' }}>
+      {/* quick tiles */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(150px,1fr))', gap: 14 }}>
+        <StatTile value={stats.total_games.toLocaleString()} label="Total matches" color="var(--blue)" />
+        <StatTile value={stats.current_streak?.length ?? 0} label={`Current streak · ${stats.current_streak?.player ?? 'None'}`} color={stats.current_streak?.player === 'Shayne' ? 'var(--shayne)' : 'var(--matt)'} />
+        <StatTile value={longestStreak} label="Longest streak" color="var(--yellow)" />
+        <StatTile value={sessionCount} label="Sessions played" color="var(--purple)" />
+      </div>
+
+      {/* head-to-head over time */}
+      {timelineData.length >= 2 && (
+        <Card>
+          <SectionTitle hint="rolling win rate · Shayne">Head-to-head over time</SectionTitle>
+          <div style={{ width: '100%', height: 180 }}>
+            <AreaChart data={timelineData} config={{ wr: { label: 'Shayne win rate', color: 'orange' } }}>
+              <Grid />
+              <YAxis tickFormatter={(v) => `${Math.round(v)}%`} />
+              <Area dataKey="wr" variant="gradient" />
+            </AreaChart>
+          </div>
+        </Card>
+      )}
+
+      {/* character win rates */}
+      <Card>
+        <SectionTitle>Character win rates</SectionTitle>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          {mergedChars.map((c) => {
+            const wr = Math.round((c.wins / c.total) * 100);
+            const color = c.player === 'Shayne' ? 'var(--shayne)' : 'var(--matt)';
+            return (
+              <div key={`${c.player}-${c.character}`} style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                <span style={{ width: 90, flex: '0 0 auto', fontSize: 13, color: 'var(--fg)', fontWeight: 500, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{c.character}</span>
+                <div style={{ flex: 1, height: 8, background: 'var(--deep1)', borderRadius: 4, overflow: 'hidden' }}>
+                  <div style={{ height: '100%', width: `${wr}%`, background: color, borderRadius: 4 }} />
+                </div>
+                <span style={{ width: 40, textAlign: 'right', fontFamily: 'var(--font-mono)', fontSize: 12, fontWeight: 700, color }}>{wr}%</span>
+                <span style={{ width: 56, textAlign: 'right', fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--faint)' }}>{c.total}g</span>
+              </div>
+            );
+          })}
+        </div>
+      </Card>
+
+      {/* recent form */}
+      <div>
+        <SectionTitle>Recent form</SectionTitle>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(180px,1fr))', gap: 14 }}>
           {[
             { label: 'Last 10', data: headToHead.recent_form.last_10 },
             { label: 'Last 20', data: headToHead.recent_form.last_20 },
             { label: 'Last 50', data: headToHead.recent_form.last_50 },
           ].map((item) => {
-            const shayneWR = ((item.data.shayne_wins / item.data.total_games) * 100).toFixed(1);
-            const mattWR = ((item.data.matt_wins / item.data.total_games) * 100).toFixed(1);
+            const tot = item.data.total_games || 1;
+            const sWR = ((item.data.shayne_wins / tot) * 100).toFixed(0);
+            const mWR = ((item.data.matt_wins / tot) * 100).toFixed(0);
             return (
-              <div key={item.label} className="stat-card" style={{ padding: '0.75rem', minHeight: 'auto' }}>
-                <div style={{ fontSize: '0.8rem', color: '#a89984', marginBottom: '0.5rem', fontWeight: '600' }}>{item.label} Games</div>
-                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.5rem' }}>
-                  <div>
-                    <div style={{ fontSize: '1.2rem', fontWeight: 'bold', color: '#fe8019' }}>{item.data.shayne_wins}</div>
-                    <div style={{ fontSize: '0.7rem', color: '#fe8019', opacity: 0.8 }}>{shayneWR}%</div>
-                  </div>
-                  <div style={{ textAlign: 'right' }}>
-                    <div style={{ fontSize: '1.2rem', fontWeight: 'bold', color: '#b8bb26' }}>{item.data.matt_wins}</div>
-                    <div style={{ fontSize: '0.7rem', color: '#b8bb26', opacity: 0.8 }}>{mattWR}%</div>
-                  </div>
+              <Card key={item.label} padding={18} style={{ borderRadius: 16 }}>
+                <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--gray)', letterSpacing: '0.5px', marginBottom: 12 }}>{item.label.toUpperCase()} GAMES</div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 10 }}>
+                  <div><div style={{ fontFamily: 'var(--font-mono)', fontSize: 22, fontWeight: 700, color: 'var(--shayne)' }}>{item.data.shayne_wins}</div><div style={{ fontSize: 11, color: 'var(--shayne)', fontFamily: 'var(--font-mono)' }}>{sWR}%</div></div>
+                  <div style={{ textAlign: 'right' }}><div style={{ fontFamily: 'var(--font-mono)', fontSize: 22, fontWeight: 700, color: 'var(--matt)' }}>{item.data.matt_wins}</div><div style={{ fontSize: 11, color: 'var(--matt)', fontFamily: 'var(--font-mono)' }}>{mWR}%</div></div>
                 </div>
-                <div style={{ 
-                  height: '4px', 
-                  background: '#3c3836', 
-                  borderRadius: '2px', 
-                  overflow: 'hidden',
-                  display: 'flex'
-                }}>
-                  <div style={{ width: `${shayneWR}%`, background: '#fe8019' }}></div>
-                  <div style={{ width: `${mattWR}%`, background: '#b8bb26' }}></div>
-                </div>
-              </div>
+                <SplitBar shayne={item.data.shayne_wins} matt={item.data.matt_wins} height={6} radius={3} />
+              </Card>
             );
           })}
         </div>
-      </section>
+      </div>
 
-      {/* ADVANCED METRICS - Compact Grid */}
-      <section className="stats-section">
-        <h2 style={{ fontSize: '1.3rem', marginBottom: '0.75rem', color: '#fbf1c7' }}>Advanced Metrics</h2>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '0.75rem' }}>
-          {/* Close Games */}
-          <div className="stat-card" style={{ padding: '0.75rem' }}>
-            <div style={{ fontSize: '0.75rem', color: '#a89984', marginBottom: '0.5rem', fontWeight: '600' }}>⚔️ Close Games</div>
-            <div style={{ fontSize: '0.7rem', color: '#a89984', marginBottom: '0.5rem' }}>1-stock victories</div>
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <div>
-                <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#fe8019' }}>{advancedMetrics.close_game_record.shayne.wins}</div>
-                <div 
-                  style={{ 
-                    fontSize: '0.7rem', 
-                    color: '#fe8019', 
-                    opacity: 0.8,
-                    cursor: 'help',
-                    position: 'relative'
-                  }}
-                  onMouseEnter={() => setActiveTooltip('close-shayne')}
-                  onMouseLeave={() => setActiveTooltip(null)}
-                >
-                  {advancedMetrics.close_game_record.shayne.win_rate}% | {advancedMetrics.close_game_record.shayne.of_all_games}%
-                </div>
-              </div>
-              <div style={{ textAlign: 'right' }}>
-                <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#b8bb26' }}>{advancedMetrics.close_game_record.matt.wins}</div>
-                <div 
-                  style={{ 
-                    fontSize: '0.7rem', 
-                    color: '#b8bb26', 
-                    opacity: 0.8,
-                    cursor: 'help',
-                    position: 'relative'
-                  }}
-                  onMouseEnter={() => setActiveTooltip('close-matt')}
-                  onMouseLeave={() => setActiveTooltip(null)}
-                >
-                  {advancedMetrics.close_game_record.matt.win_rate}% | {advancedMetrics.close_game_record.matt.of_all_games}%
-                </div>
-              </div>
-            </div>
-          </div>
-          {(activeTooltip === 'close-shayne' || activeTooltip === 'close-matt') && createPortal(
-            <div style={{
-              position: 'fixed',
-              top: '50%',
-              left: '50%',
-              transform: 'translate(-50%, -50%)',
-              backgroundColor: '#1d2021',
-              border: '2px solid #504945',
-              borderRadius: '8px',
-              padding: '0.75rem',
-              width: '280px',
-              fontSize: '0.75rem',
-              color: '#ebdbb2',
-              lineHeight: 1.5,
-              zIndex: 9999,
-              boxShadow: '0 8px 24px rgba(0,0,0,0.8)',
-              pointerEvents: 'none'
-            }}>
-              <div style={{ fontWeight: 'bold', marginBottom: '0.3rem', color: '#fabd2f' }}>1-Stock Victory Percentages</div>
-              <div style={{ marginBottom: '0.3rem' }}>
-                <span style={{ color: '#83a598', fontWeight: 'bold' }}>First %:</span> Of this player's wins, what % were 1-stock victories
-              </div>
-              <div>
-                <span style={{ color: '#83a598', fontWeight: 'bold' }}>Second %:</span> Of all games played, what % were 1-stock victories for this player
-              </div>
-            </div>,
-            document.body
-          )}
-
-          {/* Two-Stock Wins */}
-          <div className="stat-card" style={{ padding: '0.75rem' }}>
-            <div style={{ fontSize: '0.75rem', color: '#a89984', marginBottom: '0.5rem', fontWeight: '600' }}>💪 Solid Wins</div>
-            <div style={{ fontSize: '0.7rem', color: '#a89984', marginBottom: '0.5rem' }}>2-stock victories</div>
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <div>
-                <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#fe8019' }}>{advancedMetrics.two_stock_wins.shayne.two_stock_wins}</div>
-                <div 
-                  style={{ 
-                    fontSize: '0.7rem', 
-                    color: '#fe8019', 
-                    opacity: 0.8,
-                    cursor: 'help',
-                    position: 'relative'
-                  }}
-                  onMouseEnter={() => setActiveTooltip('two-shayne')}
-                  onMouseLeave={() => setActiveTooltip(null)}
-                >
-                  {advancedMetrics.two_stock_wins.shayne.two_stock_rate}% | {advancedMetrics.two_stock_wins.shayne.of_all_games}%
-                </div>
-              </div>
-              <div style={{ textAlign: 'right' }}>
-                <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#b8bb26' }}>{advancedMetrics.two_stock_wins.matt.two_stock_wins}</div>
-                <div 
-                  style={{ 
-                    fontSize: '0.7rem', 
-                    color: '#b8bb26', 
-                    opacity: 0.8,
-                    cursor: 'help',
-                    position: 'relative'
-                  }}
-                  onMouseEnter={() => setActiveTooltip('two-matt')}
-                  onMouseLeave={() => setActiveTooltip(null)}
-                >
-                  {advancedMetrics.two_stock_wins.matt.two_stock_rate}% | {advancedMetrics.two_stock_wins.matt.of_all_games}%
-                </div>
-              </div>
-            </div>
-          </div>
-          {(activeTooltip === 'two-shayne' || activeTooltip === 'two-matt') && createPortal(
-            <div style={{
-              position: 'fixed',
-              top: '50%',
-              left: '50%',
-              transform: 'translate(-50%, -50%)',
-              backgroundColor: '#1d2021',
-              border: '2px solid #504945',
-              borderRadius: '8px',
-              padding: '0.75rem',
-              width: '280px',
-              fontSize: '0.75rem',
-              color: '#ebdbb2',
-              lineHeight: 1.5,
-              zIndex: 9999,
-              boxShadow: '0 8px 24px rgba(0,0,0,0.8)',
-              pointerEvents: 'none'
-            }}>
-              <div style={{ fontWeight: 'bold', marginBottom: '0.3rem', color: '#fabd2f' }}>2-Stock Victory Percentages</div>
-              <div style={{ marginBottom: '0.3rem' }}>
-                <span style={{ color: '#83a598', fontWeight: 'bold' }}>First %:</span> Of this player's wins, what % were 2-stock victories
-              </div>
-              <div>
-                <span style={{ color: '#83a598', fontWeight: 'bold' }}>Second %:</span> Of all games played, what % were 2-stock victories for this player
-              </div>
-            </div>,
-            document.body
-          )}
-
-          {/* Dominance Factor */}
-          <div className="stat-card" style={{ padding: '0.75rem' }}>
-            <div style={{ fontSize: '0.75rem', color: '#a89984', marginBottom: '0.5rem', fontWeight: '600' }}>⚡ Dominance</div>
-            <div style={{ fontSize: '0.7rem', color: '#a89984', marginBottom: '0.5rem' }}>3-stock wins</div>
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <div>
-                <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#fe8019' }}>{advancedMetrics.dominance_factor.shayne.three_stock_wins}</div>
-                <div 
-                  style={{ 
-                    fontSize: '0.7rem', 
-                    color: '#fe8019', 
-                    opacity: 0.8,
-                    cursor: 'help',
-                    position: 'relative'
-                  }}
-                  onMouseEnter={() => setActiveTooltip('three-shayne')}
-                  onMouseLeave={() => setActiveTooltip(null)}
-                >
-                  {advancedMetrics.dominance_factor.shayne.dominance_rate}% | {advancedMetrics.dominance_factor.shayne.of_all_games}%
-                </div>
-              </div>
-              <div style={{ textAlign: 'right' }}>
-                <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#b8bb26' }}>{advancedMetrics.dominance_factor.matt.three_stock_wins}</div>
-                <div 
-                  style={{ 
-                    fontSize: '0.7rem', 
-                    color: '#b8bb26', 
-                    opacity: 0.8,
-                    cursor: 'help',
-                    position: 'relative'
-                  }}
-                  onMouseEnter={() => setActiveTooltip('three-matt')}
-                  onMouseLeave={() => setActiveTooltip(null)}
-                >
-                  {advancedMetrics.dominance_factor.matt.dominance_rate}% | {advancedMetrics.dominance_factor.matt.of_all_games}%
-                </div>
-              </div>
-            </div>
-          </div>
-          {(activeTooltip === 'three-shayne' || activeTooltip === 'three-matt') && createPortal(
-            <div style={{
-              position: 'fixed',
-              top: '50%',
-              left: '50%',
-              transform: 'translate(-50%, -50%)',
-              backgroundColor: '#1d2021',
-              border: '2px solid #504945',
-              borderRadius: '8px',
-              padding: '0.75rem',
-              width: '280px',
-              fontSize: '0.75rem',
-              color: '#ebdbb2',
-              lineHeight: 1.5,
-              zIndex: 9999,
-              boxShadow: '0 8px 24px rgba(0,0,0,0.8)',
-              pointerEvents: 'none'
-            }}>
-              <div style={{ fontWeight: 'bold', marginBottom: '0.3rem', color: '#fabd2f' }}>3-Stock Victory Percentages</div>
-              <div style={{ marginBottom: '0.3rem' }}>
-                <span style={{ color: '#83a598', fontWeight: 'bold' }}>First %:</span> Of this player's wins, what % were 3-stock victories
-              </div>
-              <div>
-                <span style={{ color: '#83a598', fontWeight: 'bold' }}>Second %:</span> Of all games played, what % were 3-stock victories for this player
-              </div>
-            </div>,
-            document.body
-          )}
-
-          {/* Avg Stock Differential */}
-          <div className="stat-card" style={{ padding: '0.75rem' }}>
-            <div style={{ fontSize: '0.75rem', color: '#a89984', marginBottom: '0.5rem', fontWeight: '600' }}>💪 Avg Stocks Left</div>
-            <div style={{ fontSize: '0.7rem', color: '#a89984', marginBottom: '0.5rem' }}>When winning</div>
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <div>
-                <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#fe8019' }}>{headToHead.avg_stock_differential.shayne}</div>
-                <div style={{ fontSize: '0.7rem', color: '#a89984' }}>Shayne</div>
-              </div>
-              <div style={{ textAlign: 'right' }}>
-                <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#b8bb26' }}>{headToHead.avg_stock_differential.matt}</div>
-                <div style={{ fontSize: '0.7rem', color: '#a89984' }}>Matt</div>
-              </div>
-            </div>
-          </div>
-
-          {/* Momentum */}
-          <div className="stat-card" style={{ padding: '0.75rem', position: 'relative' }}>
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.35rem', marginBottom: '0.5rem' }}>
-              <div style={{ fontSize: '0.75rem', color: '#a89984', fontWeight: '600' }}>📈 Momentum</div>
-              <div 
-                style={{ 
-                  cursor: 'help',
-                  fontSize: '0.65rem',
-                  color: '#665c54',
-                  fontWeight: 'normal',
-                  width: '13px',
-                  height: '13px',
-                  borderRadius: '50%',
-                  border: '1px solid #504945',
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  lineHeight: 1,
-                  position: 'relative',
-                  transition: 'all 0.2s'
-                }}
-                onMouseEnter={() => setActiveTooltip('momentum')}
-                onMouseLeave={() => setActiveTooltip(null)}
-              >
-                i
-              </div>
-              {activeTooltip === 'momentum' && createPortal(
-                <div style={{
-                  position: 'fixed',
-                  top: '50%',
-                  left: '50%',
-                  transform: 'translate(-50%, -50%)',
-                  backgroundColor: '#1d2021',
-                  border: '2px solid #504945',
-                  borderRadius: '8px',
-                  padding: '0.75rem',
-                  width: '260px',
-                  fontSize: '0.75rem',
-                  color: '#ebdbb2',
-                  lineHeight: 1.5,
-                  zIndex: 9999,
-                  boxShadow: '0 8px 24px rgba(0,0,0,0.8)',
-                  pointerEvents: 'none'
-                }}>
-                  <div style={{ fontWeight: 'bold', marginBottom: '0.3rem', color: '#fabd2f' }}>Momentum</div>
-                  Momentum measures a player's ability to chain wins together. Shows the percentage of games won immediately after winning the previous game. Higher values indicate better ability to maintain winning streaks.
-                </div>,
-                document.body
-              )}
-            </div>
-            <div style={{ fontSize: '0.7rem', color: '#a89984', marginBottom: '0.5rem', textAlign: 'center' }}>Win after win</div>
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <div>
-                <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#fe8019' }}>{advancedMetrics.momentum_analysis.shayne.win_after_win}%</div>
-                <div style={{ fontSize: '0.7rem', color: '#a89984' }}>Shayne</div>
-              </div>
-              <div style={{ textAlign: 'right' }}>
-                <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#b8bb26' }}>{advancedMetrics.momentum_analysis.matt.win_after_win}%</div>
-                <div style={{ fontSize: '0.7rem', color: '#a89984' }}>Matt</div>
-              </div>
-            </div>
-          </div>
-
-          {/* Consistency */}
-          <div className="stat-card" style={{ padding: '0.75rem', position: 'relative' }}>
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.35rem', marginBottom: '0.5rem' }}>
-              <div style={{ fontSize: '0.75rem', color: '#a89984', fontWeight: '600' }}>📊 Consistency</div>
-              <div 
-                style={{ 
-                  cursor: 'help',
-                  fontSize: '0.65rem',
-                  color: '#665c54',
-                  fontWeight: 'normal',
-                  width: '13px',
-                  height: '13px',
-                  borderRadius: '50%',
-                  border: '1px solid #504945',
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  lineHeight: 1,
-                  position: 'relative',
-                  transition: 'all 0.2s'
-                }}
-                onMouseEnter={() => setActiveTooltip('consistency')}
-                onMouseLeave={() => setActiveTooltip(null)}
-              >
-                i
-              </div>
-              {activeTooltip === 'consistency' && createPortal(
-                <div style={{
-                  position: 'fixed',
-                  top: '50%',
-                  left: '50%',
-                  transform: 'translate(-50%, -50%)',
-                  backgroundColor: '#1d2021',
-                  border: '2px solid #504945',
-                  borderRadius: '8px',
-                  padding: '0.75rem',
-                  width: '260px',
-                  fontSize: '0.75rem',
-                  color: '#ebdbb2',
-                  lineHeight: 1.5,
-                  zIndex: 9999,
-                  boxShadow: '0 8px 24px rgba(0,0,0,0.8)',
-                  pointerEvents: 'none'
-                }}>
-                  <div style={{ fontWeight: 'bold', marginBottom: '0.3rem', color: '#fabd2f' }}>Consistency</div>
-                  Consistency measures win rate volatility using the standard deviation of performance across rolling 20-game windows. Lower scores indicate more stable, predictable performance. Higher scores suggest more variable results with hot and cold streaks.
-                </div>,
-                document.body
-              )}
-            </div>
-            <div style={{ fontSize: '0.7rem', color: '#a89984', marginBottom: '0.5rem', textAlign: 'center' }}>Lower is better</div>
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <div>
-                <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#fe8019' }}>{advancedMetrics.consistency_score.shayne}</div>
-                <div style={{ fontSize: '0.7rem', color: '#a89984' }}>Shayne</div>
-              </div>
-              <div style={{ textAlign: 'right' }}>
-                <div style={{ fontSize: '1.1rem', fontWeight: 'bold', color: '#b8bb26' }}>{advancedMetrics.consistency_score.matt}</div>
-                <div style={{ fontSize: '0.7rem', color: '#a89984' }}>Matt</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* STREAK RECORDS */}
-      <section className="stats-section">
-        <h2 style={{ fontSize: '1.3rem', marginBottom: '0.75rem', color: '#fbf1c7' }}>Streak Records</h2>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '0.75rem' }}>
-          <div className="stat-card" style={{ padding: '0.75rem', background: 'linear-gradient(135deg, #3c3836 0%, #504945 100%)' }}>
-            <div style={{ fontSize: '0.75rem', color: '#a89984', marginBottom: '0.5rem', fontWeight: '600' }}>🔥 Longest Win Streak</div>
-            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '0.5rem' }}>
-              <div>
-                <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#fe8019' }}>{headToHead.streaks.longest_win_streaks.Shayne.length}</div>
-                <div style={{ fontSize: '0.7rem', color: '#a89984' }}>Shayne</div>
-              </div>
-              <div style={{ textAlign: 'right' }}>
-                <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#b8bb26' }}>{headToHead.streaks.longest_win_streaks.Matt.length}</div>
-                <div style={{ fontSize: '0.7rem', color: '#a89984' }}>Matt</div>
-              </div>
-            </div>
-          </div>
-          <div className="stat-card" style={{ padding: '0.75rem', background: 'linear-gradient(135deg, #3c3836 0%, #504945 100%)' }}>
-            <div style={{ fontSize: '0.75rem', color: '#a89984', marginBottom: '0.5rem', fontWeight: '600' }}>❄️ Longest Loss Streak</div>
-            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '0.5rem' }}>
-              <div>
-                <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#fb4934' }}>{headToHead.streaks.longest_loss_streaks.Shayne.length}</div>
-                <div style={{ fontSize: '0.7rem', color: '#a89984' }}>Shayne</div>
-              </div>
-              <div style={{ textAlign: 'right' }}>
-                <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#fb4934' }}>{headToHead.streaks.longest_loss_streaks.Matt.length}</div>
-                <div style={{ fontSize: '0.7rem', color: '#a89984' }}>Matt</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* CHARACTER WIN RATES - Compact */}
-      <section className="stats-section">
-        <h2 style={{ fontSize: '1.3rem', marginBottom: '0.75rem', color: '#fbf1c7' }}>Top Characters</h2>
-        <div className="stats-grid" style={{ gap: '1rem' }}>
-          <div className="stats-card" style={{ padding: '1rem' }}>
-            <h3 style={{ fontSize: '1.1rem', marginBottom: '1rem', textAlign: 'center', color: '#fe8019' }}>Shayne</h3>
-            <div className="character-list" style={{ gap: '0.5rem' }}>
-              {getTop5(charWinRates.shayne).map(([character, stats]) => {
-                const winRate = Math.round((stats.wins / stats.total) * 100);
-                return (
-                  <div className="character-stats" key={character} style={{ padding: '0.75rem', marginBottom: '0.5rem' }}>
-                    <div className="character-name" style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>
-                      <CharacterDisplay character={character} />
-                    </div>
-                    <div className="stats-bar" style={{ height: '24px', marginBottom: '0.4rem' }}>
-                      <div className="win-bar shayne" style={{ width: `${(stats.wins / stats.total) * 100}%`, fontSize: '0.85rem', padding: '0 0.5rem' }}>{stats.wins}W</div>
-                      <div className="loss-bar" style={{ width: `${(stats.losses / stats.total) * 100}%`, fontSize: '0.85rem', padding: '0 0.5rem' }}>{stats.losses}L</div>
-                    </div>
-                    <div className="stats-total" style={{ fontSize: '0.8rem' }}>
-                      <span className="win-rate shayne">{winRate}%</span>
-                      <span className="games-played">{stats.total} games</span>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-          <div className="stats-card" style={{ padding: '1rem' }}>
-            <h3 style={{ fontSize: '1.1rem', marginBottom: '1rem', textAlign: 'center', color: '#b8bb26' }}>Matt</h3>
-            <div className="character-list" style={{ gap: '0.5rem' }}>
-              {getTop5(charWinRates.matt).map(([character, stats]) => {
-                const winRate = Math.round((stats.wins / stats.total) * 100);
-                return (
-                  <div className="character-stats" key={character} style={{ padding: '0.75rem', marginBottom: '0.5rem' }}>
-                    <div className="character-name" style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>
-                      <CharacterDisplay character={character} />
-                    </div>
-                    <div className="stats-bar" style={{ height: '24px', marginBottom: '0.4rem' }}>
-                      <div className="win-bar matt" style={{ width: `${(stats.wins / stats.total) * 100}%`, fontSize: '0.85rem', padding: '0 0.5rem' }}>{stats.wins}W</div>
-                      <div className="loss-bar" style={{ width: `${(stats.losses / stats.total) * 100}%`, fontSize: '0.85rem', padding: '0 0.5rem' }}>{stats.losses}L</div>
-                    </div>
-                    <div className="stats-total" style={{ fontSize: '0.8rem' }}>
-                      <span className="win-rate matt">{winRate}%</span>
-                      <span className="games-played">{stats.total} games</span>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* TOP MATCHUPS - Compact */}
-      <section className="stats-section">
-        <h2 style={{ fontSize: '1.3rem', marginBottom: '0.75rem', color: '#fbf1c7' }}>Top Matchups</h2>
-        <div className="matchups-grid" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '0.75rem' }}>
-          {matchupMatrix.top_matchups.slice(0, 6).map((matchup, i) => {
-            const shayneWinRate = matchup.shayne_win_rate;
-            const mattWinRate = matchup.matt_win_rate;
+      {/* advanced metrics */}
+      <div>
+        <SectionTitle>Advanced metrics</SectionTitle>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(200px,1fr))', gap: 14 }}>
+          {metricCards.map((c) => {
+            const tip = TOOLTIPS[c.key];
             return (
-              <div className="matchup-item" key={i} style={{ padding: '0.75rem' }}>
-                <div className="matchup-header" style={{ marginBottom: '0.5rem', paddingBottom: '0.4rem' }}>
-                  <span style={{ fontSize: '0.9rem' }}>
-                    <CharacterDisplay character={matchup.shayne_character} /> vs <CharacterDisplay character={matchup.matt_character} />
-                  </span>
-                  <span style={{ fontSize: '0.75rem', padding: '0.2rem 0.4rem' }}>{matchup.total_games} games</span>
+              <Card key={c.key} padding={18} style={{ borderRadius: 16 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--fg)' }}>{c.emoji} {c.label}</span>
+                  {tip && (
+                    <span
+                      onMouseEnter={() => setActiveTooltip(c.key)}
+                      onMouseLeave={() => setActiveTooltip(null)}
+                      style={{ cursor: 'help', width: 14, height: 14, borderRadius: '50%', border: '1px solid var(--border-light)', color: 'var(--faint)', fontSize: 9, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
+                    >
+                      i
+                    </span>
+                  )}
                 </div>
-                <div className="matchup-stats">
-                  <div style={{ marginBottom: '0.5rem' }}>
-                    <div style={{ fontSize: '0.75rem', marginBottom: '0.2rem' }}>Shayne</div>
-                    <div className="win-count" style={{ fontSize: '1rem', marginBottom: '0.3rem' }}>
-                      {matchup.shayne_wins}
-                      <span className="win-percentage" style={{ fontSize: '0.8rem' }}> ({shayneWinRate}%)</span>
-                    </div>
-                    <div className="win-rate-bar" style={{ height: '4px' }}>
-                      <div className="win-rate-fill" style={{ width: `${shayneWinRate}%`, background: '#fe8019' }}></div>
-                    </div>
-                  </div>
-                  <div>
-                    <div style={{ fontSize: '0.75rem', marginBottom: '0.2rem' }}>Matt</div>
-                    <div className="win-count" style={{ fontSize: '1rem', marginBottom: '0.3rem' }}>
-                      {matchup.matt_wins}
-                      <span className="win-percentage" style={{ fontSize: '0.8rem' }}> ({mattWinRate}%)</span>
-                    </div>
-                    <div className="win-rate-bar" style={{ height: '4px' }}>
-                      <div className="win-rate-fill" style={{ width: `${mattWinRate}%`, background: '#b8bb26' }}></div>
-                    </div>
-                  </div>
+                <div style={{ fontSize: 11, color: 'var(--faint)', fontFamily: 'var(--font-mono)', margin: '2px 0 12px' }}>{c.sub}</div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
+                  <div><div style={{ fontFamily: 'var(--font-mono)', fontSize: 20, fontWeight: 700, color: 'var(--shayne)' }}>{c.s}</div>{'sSub' in c && c.sSub ? <div style={{ fontSize: 10, color: 'var(--gray)', fontFamily: 'var(--font-mono)' }}>{c.sSub}</div> : <div style={{ fontSize: 10, color: 'var(--gray)' }}>Shayne</div>}</div>
+                  <div style={{ textAlign: 'right' }}><div style={{ fontFamily: 'var(--font-mono)', fontSize: 20, fontWeight: 700, color: 'var(--matt)' }}>{c.m}</div>{'mSub' in c && c.mSub ? <div style={{ fontSize: 10, color: 'var(--gray)', fontFamily: 'var(--font-mono)' }}>{c.mSub}</div> : <div style={{ fontSize: 10, color: 'var(--gray)' }}>Matt</div>}</div>
                 </div>
-              </div>
+              </Card>
             );
           })}
         </div>
-      </section>
+      </div>
 
-      {/* MONTHLY ACTIVITY CHART - Compact */}
-      <section className="stats-section">
-        <h2 style={{ fontSize: '1.3rem', marginBottom: '0.75rem', color: '#fbf1c7' }}>Games by Month</h2>
-        <div className="card" style={{ padding: '1rem' }}>
-          <div style={{ width: '100%', height: 300 }}>
-            <BarChart data={monthlyChartData} config={{ games: { label: 'Games', color: 'blue' } }}>
-              <XAxis dataKey="month" />
-              <YAxis />
-              <Tooltip labelKey="month" />
-              <Bar dataKey="games" variant="gradient" />
-            </BarChart>
-          </div>
+      {/* streak records */}
+      <div>
+        <SectionTitle>Streak records</SectionTitle>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(220px,1fr))', gap: 14 }}>
+          {[
+            { label: '🔥 LONGEST WIN STREAK', s: headToHead.streaks.longest_win_streaks.Shayne.length, m: headToHead.streaks.longest_win_streaks.Matt.length, sc: 'var(--shayne)', mc: 'var(--matt)' },
+            { label: '❄️ LONGEST LOSS STREAK', s: headToHead.streaks.longest_loss_streaks.Shayne.length, m: headToHead.streaks.longest_loss_streaks.Matt.length, sc: 'var(--red)', mc: 'var(--red)' },
+          ].map((s) => (
+            <GlowPanel key={s.label} style={{ borderRadius: 16, padding: '18px 20px' }}>
+              <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--gray)', letterSpacing: '0.5px', marginBottom: 14 }}>{s.label}</div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
+                <div><div style={{ fontFamily: 'var(--font-mono)', fontSize: 30, fontWeight: 700, color: s.sc, lineHeight: 1 }}>{s.s}</div><div style={{ fontSize: 11, color: 'var(--gray)', marginTop: 4 }}>Shayne</div></div>
+                <div style={{ textAlign: 'right' }}><div style={{ fontFamily: 'var(--font-mono)', fontSize: 30, fontWeight: 700, color: s.mc, lineHeight: 1 }}>{s.m}</div><div style={{ fontSize: 11, color: 'var(--gray)', marginTop: 4 }}>Matt</div></div>
+              </div>
+            </GlowPanel>
+          ))}
         </div>
-      </section>
+      </div>
 
-    </div>
+      {/* top characters */}
+      <div>
+        <SectionTitle>Top characters</SectionTitle>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(280px,1fr))', gap: 20 }}>
+          {([['Shayne', charWinRates.shayne, 'var(--shayne)'], ['Matt', charWinRates.matt, 'var(--matt)']] as const).map(([name, data, color]) => (
+            <Card key={name} padding={20}>
+              <div style={{ fontSize: 13, fontWeight: 700, color, textAlign: 'center', marginBottom: 16 }}>{name}</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 13 }}>
+                {getTop5(data).map(([character, s]) => {
+                  const wr = Math.round((s.wins / s.total) * 100);
+                  const wPct = (s.wins / s.total) * 100;
+                  return (
+                    <div key={character}>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 5, alignItems: 'center' }}>
+                        <CharacterDisplay character={character} textClassName="stat-char-name" />
+                        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--gray)' }}>{wr}% · {s.total}</span>
+                      </div>
+                      <div style={{ display: 'flex', height: 18, borderRadius: 5, overflow: 'hidden', fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 700, color: '#1b1817' }}>
+                        <div style={{ width: `${wPct}%`, background: color, display: 'flex', alignItems: 'center', paddingLeft: 6, minWidth: 24 }}>{s.wins}</div>
+                        <div style={{ width: `${100 - wPct}%`, background: 'var(--border-light)', display: 'flex', alignItems: 'center', justifyContent: 'flex-end', paddingRight: 6, color: 'var(--fg)', minWidth: 24 }}>{s.losses}</div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </Card>
+          ))}
+        </div>
+      </div>
+
+      {/* top matchups */}
+      <div>
+        <SectionTitle>Top matchups</SectionTitle>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(240px,1fr))', gap: 14 }}>
+          {matchupMatrix.top_matchups.slice(0, 6).map((mu, i) => (
+            <Card key={i} padding={18} style={{ borderRadius: 16 }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', paddingBottom: 10, marginBottom: 10, borderBottom: '1px solid var(--line-2)' }}>
+                <span style={{ fontSize: 13, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <span style={{ color: 'var(--shayne)' }}>{mu.shayne_character}</span>
+                  <span style={{ color: 'var(--faint)' }}>vs</span>
+                  <span style={{ color: 'var(--matt)' }}>{mu.matt_character}</span>
+                </span>
+                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--faint)' }}>{mu.total_games}g</span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--shayne)', fontWeight: 700 }}>{mu.shayne_wins} <span style={{ color: 'var(--gray)', fontWeight: 400 }}>{mu.shayne_win_rate}%</span></span>
+                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--matt)', fontWeight: 700 }}><span style={{ color: 'var(--gray)', fontWeight: 400 }}>{mu.matt_win_rate}%</span> {mu.matt_wins}</span>
+              </div>
+              <SplitBar shayne={mu.shayne_wins} matt={mu.matt_wins} height={6} radius={3} />
+            </Card>
+          ))}
+        </div>
+      </div>
+
+      {/* games by month */}
+      <Card>
+        <SectionTitle>Games by month</SectionTitle>
+        <div style={{ width: '100%', height: 260 }}>
+          <BarChart data={monthlyChartData} config={{ games: { label: 'Games', color: 'blue' } }}>
+            <XAxis dataKey="month" />
+            <YAxis />
+            <Tooltip labelKey="month" />
+            <Bar dataKey="games" variant="gradient" />
+          </BarChart>
+        </div>
+      </Card>
+
+      {/* NEW: heatmap + stage win rates */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(320px,1fr))', gap: 20 }}>
+        <Card>
+          <SectionTitle hint="new · Shayne">Performance by day &amp; time</SectionTitle>
+          {heatCells.length > 0 ? (
+            <DitherHeatmap cells={heatCells} height={220} metricLabel="win rate" />
+          ) : (
+            <div style={{ fontSize: 12, color: 'var(--faint)', fontFamily: 'var(--font-mono)' }}>Not enough data</div>
+          )}
+        </Card>
+        <Card>
+          <SectionTitle hint="new · Shayne">Stage win rates</SectionTitle>
+          {stageStats.length > 0 ? (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+              {stageStats.slice(0, 8).map((st) => (
+                <div key={st.stage} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <span style={{ fontSize: 12, color: 'var(--fg)', width: 110, flex: '0 0 auto', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{st.stage}</span>
+                  <div style={{ flex: 1, height: 7, background: 'var(--deep1)', borderRadius: 4, overflow: 'hidden' }}>
+                    <div style={{ height: '100%', width: `${st.winRate}%`, background: 'var(--shayne)', borderRadius: 4 }} />
+                  </div>
+                  <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--gray)', width: 34, textAlign: 'right' }}>{Math.round(st.winRate)}%</span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div style={{ fontSize: 12, color: 'var(--faint)', fontFamily: 'var(--font-mono)' }}>Not enough data</div>
+          )}
+        </Card>
+      </div>
+
+      {/* metric tooltips */}
+      {activeTooltip && TOOLTIPS[activeTooltip] && createPortal(
+        <div style={{ position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%,-50%)', background: 'var(--deep2)', border: '1px solid var(--border-light)', borderRadius: 10, padding: 14, width: 280, fontSize: 12, color: 'var(--fg)', lineHeight: 1.5, zIndex: 9999, boxShadow: '0 8px 24px rgba(0,0,0,0.8)', pointerEvents: 'none' }}>
+          <div style={{ fontWeight: 700, marginBottom: 6, color: 'var(--yellow)' }}>{TOOLTIPS[activeTooltip].title}</div>
+          {TOOLTIPS[activeTooltip].body}
+        </div>,
+        document.body,
+      )}
+    </PageColumn>
   );
 };
 

--- a/frontend/src/components/ui.tsx
+++ b/frontend/src/components/ui.tsx
@@ -1,0 +1,146 @@
+// Shared page-level UI primitives for the interior platform pages (Statistics,
+// Character Analytics, Session History/Detail, Tearsheet). These carry the
+// redesign's visual language — the app shell already provides the sidebar; these
+// build the main content column that sits inside it.
+import type { CSSProperties, ReactNode } from 'react';
+
+/** The main content column: matches the design's `padding:30px 34px; gap:22px`,
+ *  tightened on mobile. Every interior page wraps its body in this. */
+export function PageColumn({ children, gap = 22 }: { children: ReactNode; gap?: number }) {
+  return (
+    <div className="page-column" style={{ minWidth: 0, display: 'flex', flexDirection: 'column', gap }}>
+      {children}
+      <style>{`
+        .page-column { padding: 30px 34px; }
+        @media (max-width: 640px) { .page-column { padding: 18px 16px; } }
+      `}</style>
+    </div>
+  );
+}
+
+/** Page title + mono subtitle, with an optional right-aligned action slot. */
+export function PageHeader({
+  title,
+  subtitle,
+  action,
+}: {
+  title: string;
+  subtitle?: string;
+  action?: ReactNode;
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', gap: 16, flexWrap: 'wrap' }}>
+      <div style={{ minWidth: 0 }}>
+        <h2 style={{ fontSize: 26, fontWeight: 700, color: 'var(--fg-light)', letterSpacing: '-0.5px', margin: 0, fontFamily: 'var(--font-display)' }}>
+          {title}
+        </h2>
+        {subtitle && (
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--gray)', marginTop: 6 }}>{subtitle}</div>
+        )}
+      </div>
+      {action}
+    </div>
+  );
+}
+
+/** A section heading inside a page column. */
+export function SectionTitle({ children, hint }: { children: ReactNode; hint?: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 14, gap: 12 }}>
+      <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg-light)', fontFamily: 'var(--font-display)' }}>{children}</span>
+      {hint && <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--gray)' }}>{hint}</span>}
+    </div>
+  );
+}
+
+/** A bordered panel surface (the --panel card used everywhere). */
+export function Card({ children, style, padding = 22 }: { children: ReactNode; style?: CSSProperties; padding?: number }) {
+  return (
+    <div style={{ background: 'var(--panel)', border: '1px solid var(--line-2)', borderRadius: 18, padding, ...style }}>
+      {children}
+    </div>
+  );
+}
+
+/** The dark gradient hero with two side radial glows (Statistics/Session hero). */
+export function GlowPanel({ children, style }: { children: ReactNode; style?: CSSProperties }) {
+  return (
+    <div
+      style={{
+        position: 'relative',
+        overflow: 'hidden',
+        borderRadius: 24,
+        border: '1px solid var(--line)',
+        background: 'linear-gradient(135deg,#221f1e,#1a1716)',
+        ...style,
+      }}
+    >
+      <div style={{ position: 'absolute', top: '-50%', left: '-6%', width: '44%', height: '200%', background: 'radial-gradient(circle,rgba(254,128,25,0.13),transparent 62%)' }} />
+      <div style={{ position: 'absolute', top: '-50%', right: '-6%', width: '44%', height: '200%', background: 'radial-gradient(circle,rgba(184,187,38,0.13),transparent 62%)' }} />
+      <div style={{ position: 'relative' }}>{children}</div>
+    </div>
+  );
+}
+
+/** A single stat tile: big mono value + label. `caps` puts a small uppercase
+ *  label above the value instead (Session History variant). */
+export function StatTile({
+  value,
+  label,
+  color = 'var(--fg-light)',
+  caps = false,
+}: {
+  value: ReactNode;
+  label: string;
+  color?: string;
+  caps?: boolean;
+}) {
+  if (caps) {
+    return (
+      <div style={{ background: 'var(--panel)', border: '1px solid var(--line-2)', borderRadius: 16, padding: 18 }}>
+        <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--gray)', letterSpacing: '0.5px', textTransform: 'uppercase', marginBottom: 8 }}>{label}</div>
+        <div style={{ fontFamily: 'var(--font-mono)', fontSize: 26, fontWeight: 700, color }}>{value}</div>
+      </div>
+    );
+  }
+  return (
+    <div style={{ background: 'var(--panel)', border: '1px solid var(--line-2)', borderRadius: 16, padding: 18 }}>
+      <div style={{ fontFamily: 'var(--font-mono)', fontSize: 26, fontWeight: 700, color }}>{value}</div>
+      <div style={{ fontSize: 11, color: 'var(--gray)', marginTop: 5 }}>{label}</div>
+    </div>
+  );
+}
+
+const TIER_COLOR: Record<string, string> = {
+  S: '#fabd2f',
+  A: '#8ec07c',
+  B: '#83a598',
+  C: '#665c54',
+};
+
+/** Win-rate tier badge (S/A/B/C). */
+export function TierBadge({ tier }: { tier: string }) {
+  return (
+    <span
+      style={{
+        fontFamily: 'var(--font-mono)',
+        fontSize: 11,
+        fontWeight: 700,
+        padding: '2px 7px',
+        borderRadius: 6,
+        color: '#1b1817',
+        background: TIER_COLOR[tier] ?? 'var(--faint)',
+      }}
+    >
+      {tier}
+    </span>
+  );
+}
+
+/** Win-rate -> tier band. */
+export function winRateTier(winRatePct: number): string {
+  if (winRatePct >= 55) return 'S';
+  if (winRatePct >= 50) return 'A';
+  if (winRatePct >= 45) return 'B';
+  return 'C';
+}


### PR DESCRIPTION
Implements the **second** "Smash Rivalry Redesign" handoff — the *Platform pages*
section (I–M). Where PR #5 built the Session command center and re-framed the
interior pages into the new shell but left their internals untouched, this PR
propagates the redesign's visual language across all five interior pages.

**Frontend-only.** Every section maps to endpoints the pages already fetch — even
the two "new" Statistics widgets (day/time heatmap, stage win-rates) wire to
existing `/api/users/<player>/heatmap` and `/stats`. No backend change.

## Pages reskinned

- **Statistics** (`/stats`) — H2H hero (dither donut + all-time record), quick
  tiles, rolling win-rate area chart, character win-rate bars, recent form,
  advanced metrics (**hover tooltips kept**, per the handoff), streak records, top
  characters/matchups, games-by-month bar, plus two **new** widgets: a day/time
  `DitherHeatmap` and stage win-rate bars.
- **Character Analytics** (`/characters`) — highest-win-rate callout (filtered
  ≥20 games), win-rate distribution + top-usage bar charts, and a roster grid
  **ranked by win rate with real roster icons and S/A/B/C tier badges** linking to
  each character's detail.
- **Session History** (`/sessions`) — summary tiles, stacked activity chart, min-
  games filter, and the session card grid with split bars and winner badges.
- **Session Detail** (`/sessions/:id`) — score hero + dither donut, character
  matchups, usage, stage-art breakdown, and the editable matches list.
- **Session Tearsheet** (`/session-tearsheet`) — reskinned 800px shareable artifact
  with the export toolbar; **html2canvas PNG export/copy preserved and verified**.

## Shared primitives

New `components/ui.tsx` (PageColumn, PageHeader, SectionTitle, Card, GlowPanel,
StatTile, TierBadge, winRateTier) — the content-column building blocks, reused
across all five pages for consistency.

## Preserved wiring (this is a reskin, not a behavior change)

Every fetch, response field name, `.success` guard, dither-chart `dataKey`/`config`
key, the `MatchEditorModal` edit flow, and the `html2canvas` capture are unchanged.
Loading/error states migrated to the shared `Feedback` components.

## Deliberate design call

The **tearsheet card uses literal hex** (not CSS vars) inside the html2canvas-
captured region, so the exported PNG renders identically regardless of theme or
the capture engine's var handling. The rest of the app uses CSS variables.

## Test plan

- [x] `tsc -b` clean; `eslint` 0 errors (2 benign warnings matching existing
  conventions); `vite build` passes.
- [x] All five pages verified via Playwright against the real 3,197-match CSV
  (desktop 1440px + mobile 392px) — no console errors, no horizontal overflow.
- [x] Tearsheet **PNG export driven end-to-end**: Download PNG produces a valid
  1.2 MB image with real character icons, stage art, gradients, and both web fonts.
- [ ] Reviewer smoke: open each page; on Session Detail edit/delete a match; on the
  tearsheet click Copy to clipboard and Download PNG.

## Notes

- Depends on nothing beyond `main` (PR #5 merged). Branches off `main`.
- The `MatchEditorModal` (top-level) is still used by Session Detail and kept.
- The new handoff zip in the repo root is left untracked (not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
